### PR TITLE
Package the checks as an OCI container for usage in Kubernetes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,3 +81,88 @@ jobs:
           pushd $OSC_CHECKOUT_DIR
           osc ar
           osc commit -m "GitHub Actions automated update to reference ${{ github.sha }}"
+
+  obs-commit-image:
+    name: Commit to OBS to generate a container image
+    runs-on: ubuntu-20.04
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    needs: [tlint]
+    container:
+      image: ghcr.io/trento-project/continuous-delivery:main
+      env:
+        FOLDER: packaging/suse/container
+        NAME: trento-checks-image
+        OBS_PASS: ${{ secrets.OBS_PASS }}
+        OBS_PROJECT: ${{ secrets.OBS_PROJECT }}
+        OBS_USER: ${{ secrets.OBS_USER }}
+        OSC_CHECKOUT_DIR: /tmp/trento-checks-image
+        REPOSITORY: ${{ github.repository }}
+      options: -u 0:0
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: latest-tag
+        with:
+          semver_only: true
+          initial_version: 0.0.1
+      - name: Configure OSC
+        run: |
+          mkdir -p $HOME/.config/osc
+          cp /home/osc/.config/osc/oscrc $HOME/.config/osc
+          /scripts/init_osc_creds.sh
+      - name: Prepare .changes file
+        # The .changes file is updated only in release creation. This current task should be improved
+        # in order to add the current rolling release notes
+        if: github.event_name == 'release'
+        run: |
+          CHANGES_FILE=$NAME.changes
+          osc checkout $OBS_PROJECT $NAME $CHANGES_FILE
+          mv $CHANGES_FILE $FOLDER
+          VERSION=${{ steps.latest-tag.outputs.tag }}
+          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $VERSION -f $FOLDER/$CHANGES_FILE
+      - name: Set version
+        run: |
+          git config --global --add safe.directory /__w/checks/checks
+          VERSION=$(./hack/get_version_from_git.sh)
+          # "+" character is not allowed in OBS dockerfile version strings
+          VERSION=${VERSION//[+]/-}
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/Dockerfile
+      - name: Commit on OBS
+        run: |
+          OBS_PACKAGE=$OBS_PROJECT/$NAME
+          osc checkout $OBS_PACKAGE -o $OSC_CHECKOUT_DIR
+          cp -r $FOLDER/* $OSC_CHECKOUT_DIR
+          tar --transform 's,^./,/checks/,' -zcvf $OSC_CHECKOUT_DIR/checks.tar.gz --exclude=./.git ./*
+          cd $OSC_CHECKOUT_DIR
+          osc ar
+          osc commit -m "New development version of $NAME released"
+      # - name: Checkout and prepare OBS package
+      #   run: |
+      #     osc checkout $OBS_PROJECT trento-checks -o $OSC_CHECKOUT_DIR
+      #     cp $FOLDER/_service $OSC_CHECKOUT_DIR
+      #     cp $FOLDER/trento-checks.spec $OSC_CHECKOUT_DIR
+      #     rm -vf $OSC_CHECKOUT_DIR/*.tar.gz
+      #     pushd $OSC_CHECKOUT_DIR
+      #     osc service manualrun
+      #     rm -vf $OSC_CHECKOUT_DIR/*.tgz
+      # - name: Prepare trento-checks.changes file
+      #   # The .changes file is updated only in release creation. This current task should be improved
+      #   # in order to add the current rolling release notes
+      #   if: github.event_name == 'release'
+      #   run: |
+      #     git config --global --add safe.directory /__w/checks/checks
+      #     VERSION=$(./hack/get_version_from_git.sh)
+      #     TAG=$(echo $VERSION | cut -f1 -d+)
+      #     hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $OSC_CHECKOUT_DIR/trento-checks.changes
+      # - name: Commit changes into OBS
+      #   run: |
+      #     pushd $OSC_CHECKOUT_DIR
+      #     osc ar
+      #     osc commit -m "GitHub Actions automated update to reference ${{ github.sha }}"
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,27 +142,4 @@ jobs:
           cd $OSC_CHECKOUT_DIR
           osc ar
           osc commit -m "New development version of $NAME released"
-      # - name: Checkout and prepare OBS package
-      #   run: |
-      #     osc checkout $OBS_PROJECT trento-checks -o $OSC_CHECKOUT_DIR
-      #     cp $FOLDER/_service $OSC_CHECKOUT_DIR
-      #     cp $FOLDER/trento-checks.spec $OSC_CHECKOUT_DIR
-      #     rm -vf $OSC_CHECKOUT_DIR/*.tar.gz
-      #     pushd $OSC_CHECKOUT_DIR
-      #     osc service manualrun
-      #     rm -vf $OSC_CHECKOUT_DIR/*.tgz
-      # - name: Prepare trento-checks.changes file
-      #   # The .changes file is updated only in release creation. This current task should be improved
-      #   # in order to add the current rolling release notes
-      #   if: github.event_name == 'release'
-      #   run: |
-      #     git config --global --add safe.directory /__w/checks/checks
-      #     VERSION=$(./hack/get_version_from_git.sh)
-      #     TAG=$(echo $VERSION | cut -f1 -d+)
-      #     hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $OSC_CHECKOUT_DIR/trento-checks.changes
-      # - name: Commit changes into OBS
-      #   run: |
-      #     pushd $OSC_CHECKOUT_DIR
-      #     osc ar
-      #     osc commit -m "GitHub Actions automated update to reference ${{ github.sha }}"
 

--- a/bin/trento-install-checks
+++ b/bin/trento-install-checks
@@ -10,9 +10,18 @@
 checks_src="/usr/local/src/trento-checks/checks"
 checks_dst="/usr/share/trento/checks"
 
-if [ ! -e "$checks_dst" ] && [ -d "$checks_src" ]; then
-  mkdir -p "$checks_dst"
-  install -p -m 0644 "$checks_src"/* "$checks_dst"
+if [ -d "$checks_dst" ] && [ -n "$(find "$checks_dst" -maxdepth 0 -type d -empty 2>/dev/null)" ]; then
+  if [ ! -d "$checks_src" ]; then
+    echo "Make sure the checks are installed to $checks_src" 1>&2
+
+    # FIXME: handle via trap
+    unset checks_src
+    unset checks_dst
+
+    exit 1
+  fi
+
+  install -p -m 0644 "$checks_src"/* "$checks_dst" || echo "Make sure $checks_dst exists, is empty and accessible" 1>&2
 
   # FIXME: handle via trap
   unset checks_src
@@ -21,7 +30,10 @@ if [ ! -e "$checks_dst" ] && [ -d "$checks_src" ]; then
   exit $?
 fi
 
+echo "Make sure $checks_dst exists, is empty and accessible" 1>&2
+
 # FIXME: handle via trap
 unset checks_src
 unset checks_dst
+
 exit 1

--- a/bin/trento-install-checks
+++ b/bin/trento-install-checks
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+#  trento-install-checks
+#
+#  This script installs the checks into the directory Wanda expects them.  It
+#  is required, for Kubernetes style sidecar containers and should not be used
+#  in regular deployments using docker
+#
+
+checks_src="/usr/local/src/trento-checks/checks"
+checks_dst="/usr/share/trento/checks"
+
+if [ ! -e "$checks_dst" ] && [ -d "$checks_src" ]; then
+  mkdir -p "$checks_dst"
+  install -p -m 0644 "$checks_src"/* "$checks_dst"
+
+  # FIXME: handle via trap
+  unset checks_src
+  unset checks_dst
+
+  exit $?
+fi
+
+# FIXME: handle via trap
+unset checks_src
+unset checks_dst
+exit 1

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -1,0 +1,18 @@
+FROM bci/bci-base:15.4
+
+LABEL org.opencontainers.image.source="https://github.com/trento-project/checks"
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# tar is required by kubectl cp
+RUN zypper --non-interactive in -y tar && \
+    zypper --non-interactive clean
+
+COPY checks /usr/local/src/trento-checks/checks
+COPY bin/trento-install-checks /usr/local/bin/trento-install-checks
+
+RUN chmod +x /usr/local/bin/trento-install-checks
+
+ENTRYPOINT ["/usr/local/bin/trento-install-checks"]

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#!BuildTag: trento/trento-checks:latest
+#!BuildTag: trento/trento-checks:%%VERSION%%
+#!BuildTag: trento/trento-checks:%%VERSION%%-build%RELEASE%
+#!UseOBSRepositories
+#!ExclusiveArch: x86_64
 FROM bci/bci-base:15.4
 
 LABEL org.opencontainers.image.source="https://github.com/trento-project/checks"
@@ -11,8 +17,8 @@ RUN zypper --non-interactive in -y tar && \
     zypper --non-interactive clean
 
 COPY checks /usr/local/src/trento-checks/checks
-COPY bin/trento-install-checks /usr/local/bin/trento-install-checks
 
+COPY bin/trento-install-checks /usr/local/bin/trento-install-checks
 RUN chmod +x /usr/local/bin/trento-install-checks
 
 ENTRYPOINT ["/usr/local/bin/trento-install-checks"]

--- a/packaging/suse/container/_constraints
+++ b/packaging/suse/container/_constraints
@@ -1,0 +1,7 @@
+<constraints>
+  <hardware>
+    <disk>
+      <size unit="G">8</size>
+    </disk>
+  </hardware>
+</constraints>

--- a/packaging/suse/container/_service
+++ b/packaging/suse/container/_service
@@ -1,0 +1,4 @@
+<services>
+  <service mode="buildtime" name="docker_label_helper"/>
+  <service mode="buildtime" name="kiwi_metainfo_helper"/>
+</services>


### PR DESCRIPTION
This PR packages the checks as an OCI container, so it can be used as a side car in Kubernetes and possibly in manual Docker/Podman deployments.

It intentionally installs the checks during runtime, so a volume can be mounted to `/usr/share/trento/checks`.