### PR TITLE
Remove explicit file listing from RPM spec

### DIFF
--- a/packaging/suse/rpm/trento-checks.spec
+++ b/packaging/suse/rpm/trento-checks.spec
@@ -48,5 +48,6 @@ install -p -m 0644 checks/* %{buildroot}%{trento_checks_dir}
 %license LICENSE
 %dir %{trento_dir}
 %dir %{trento_checks_dir}
+%{trento_checks_dir}/*
 
 %changelog


### PR DESCRIPTION
As discussed with Alessio and the packaging team, it can be beneficial to remove the explicit listing of files for ease or maintenance

Not tested, yet therefore a draft