### PR TITLE
Add hana scenario for hana_scale up  cluster type

### DIFF
--- a/checks/00081D.yaml
+++ b/checks/00081D.yaml
@@ -52,7 +52,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: max_messages
     gatherer: corosync-cmapctl@v1

--- a/checks/0B0F87.yaml
+++ b/checks/0B0F87.yaml
@@ -35,6 +35,7 @@ remediation: |
 metadata:
   target_type: cluster
   cluster_type: hana_scale_up
+  hana_scenario: performance_optimized
   architecture_type: classic
 
 facts:

--- a/checks/0B6DB2.yaml
+++ b/checks/0B6DB2.yaml
@@ -56,6 +56,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
+  hana_scenario: performance_optimized
   provider: [azure, nutanix, kvm, vmware]
 
 facts:

--- a/checks/156F64.yaml
+++ b/checks/156F64.yaml
@@ -53,7 +53,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_token_timeout
     gatherer: corosync.conf@v1

--- a/checks/15F7A8.yaml
+++ b/checks/15F7A8.yaml
@@ -52,7 +52,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: token_retransmits
     gatherer: corosync-cmapctl@v1

--- a/checks/205AF7.yaml
+++ b/checks/205AF7.yaml
@@ -48,7 +48,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: crm_config_properties
     gatherer: cibadmin@v1

--- a/checks/21FCA6.yaml
+++ b/checks/21FCA6.yaml
@@ -53,7 +53,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_token_retransmits_before_loss_const
     gatherer: corosync.conf@v1

--- a/checks/222A57.yaml
+++ b/checks/222A57.yaml
@@ -21,7 +21,7 @@ metadata:
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-
+  hana_scenario: performance_optimized
 facts:
   - name: compare_sbd_version
     gatherer: package_version@v1

--- a/checks/24ABCB.yaml
+++ b/checks/24ABCB.yaml
@@ -48,7 +48,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_join_timeout
     gatherer: corosync.conf@v1

--- a/checks/31BDCB.yaml
+++ b/checks/31BDCB.yaml
@@ -18,7 +18,7 @@ metadata:
   target_type: cluster
   cluster_type: hana_scale_up
   architecture_type: classic
-
+  hana_scenario: performance_optimized
 facts:
   - name: compare_SAPHanaSR_version
     gatherer: package_version@v1

--- a/checks/32CFC6.yaml
+++ b/checks/32CFC6.yaml
@@ -43,7 +43,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: totem_interfaces
     gatherer: corosync-cmapctl@v1

--- a/checks/33403D.yaml
+++ b/checks/33403D.yaml
@@ -71,7 +71,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_transport_protocol
     gatherer: corosync.conf@v1

--- a/checks/373DB8.yaml
+++ b/checks/373DB8.yaml
@@ -47,7 +47,7 @@ metadata:
   cluster_type: 
     - hana_scale_up
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: crm_config_properties
     gatherer: cibadmin@v1

--- a/checks/438525.yaml
+++ b/checks/438525.yaml
@@ -46,7 +46,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: hosts
     gatherer: hosts@v1

--- a/checks/49591F.yaml
+++ b/checks/49591F.yaml
@@ -54,7 +54,7 @@ metadata:
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-
+  hana_scenario: performance_optimized
 facts:
   - name: sbd_startmode
     gatherer: sbd_config@v1

--- a/checks/53D035.yaml
+++ b/checks/53D035.yaml
@@ -54,7 +54,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: token_timeout
     gatherer: corosync-cmapctl@v1

--- a/checks/53D33E.yaml
+++ b/checks/53D33E.yaml
@@ -21,6 +21,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
+  hana_scenario: performance_optimized
   provider: [azure, nutanix, kvm, vmware]
 
 facts:

--- a/checks/61451E.yaml
+++ b/checks/61451E.yaml
@@ -38,6 +38,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
+  hana_scenario: performance_optimized
   provider: [azure, nutanix, kvm, vmware]
 
 facts:

--- a/checks/68626E.yaml
+++ b/checks/68626E.yaml
@@ -39,6 +39,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
+  hana_scenario: performance_optimized
   provider: [azure, nutanix, kvm, vmware]
 
 facts:

--- a/checks/6E0DEC.yaml
+++ b/checks/6E0DEC.yaml
@@ -25,6 +25,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
+  hana_scenario: performance_optimized
   provider: azure
 
 facts:

--- a/checks/6E9B82.yaml
+++ b/checks/6E9B82.yaml
@@ -51,7 +51,7 @@ metadata:
   cluster_type: 
     - hana_scale_up
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_twonode
     gatherer: corosync.conf@v1

--- a/checks/790926.yaml
+++ b/checks/790926.yaml
@@ -43,7 +43,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: hacluster_has_default_password
     gatherer: verify_password@v1

--- a/checks/7E0221.yaml
+++ b/checks/7E0221.yaml
@@ -73,7 +73,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: runtime_transport
     gatherer: corosync-cmapctl@v1

--- a/checks/816815.yaml
+++ b/checks/816815.yaml
@@ -38,7 +38,7 @@ metadata:
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-
+  hana_scenario: performance_optimized
 facts:
   - name: sbd_service_state
     gatherer: systemd@v2

--- a/checks/822E47.yaml
+++ b/checks/822E47.yaml
@@ -52,7 +52,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: runtime_join
     gatherer: corosync-cmapctl@v1

--- a/checks/82A031.yaml
+++ b/checks/82A031.yaml
@@ -21,7 +21,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: installed_pacemaker_version
     gatherer: package_version@v1

--- a/checks/845CC9.yaml
+++ b/checks/845CC9.yaml
@@ -53,7 +53,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_max_messages
     gatherer: corosync.conf@v1

--- a/checks/9FAAD0.yaml
+++ b/checks/9FAAD0.yaml
@@ -17,7 +17,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: exclude_package_pacemaker
     gatherer: package_version@v1

--- a/checks/9FEFB0.yaml
+++ b/checks/9FEFB0.yaml
@@ -19,7 +19,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: compare_pacemaker_version
     gatherer: package_version@v1

--- a/checks/A1244C.yaml
+++ b/checks/A1244C.yaml
@@ -53,7 +53,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_consensus_timeout
     gatherer: corosync.conf@v1

--- a/checks/ABA3CA.yaml
+++ b/checks/ABA3CA.yaml
@@ -42,7 +42,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: saphostctrl_ping
     gatherer: saphostctrl@v1

--- a/checks/B089BE.yaml
+++ b/checks/B089BE.yaml
@@ -38,7 +38,7 @@ metadata:
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-
+  hana_scenario: performance_optimized
 facts:
   - name: dump_sbd_devices
     gatherer: sbd_dump@v1

--- a/checks/B3DA7E.yaml
+++ b/checks/B3DA7E.yaml
@@ -48,7 +48,7 @@ metadata:
   cluster_type: 
     - hana_scale_up
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: resource_options
     gatherer: cibadmin@v1

--- a/checks/BA215C.yaml
+++ b/checks/BA215C.yaml
@@ -38,7 +38,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_conf_file_content
     gatherer: corosync.conf@v1

--- a/checks/BC9DF9.yaml
+++ b/checks/BC9DF9.yaml
@@ -20,7 +20,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: installed_python3_version
     gatherer: package_version@v1

--- a/checks/C3166E.yaml
+++ b/checks/C3166E.yaml
@@ -17,7 +17,7 @@ metadata:
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-
+  hana_scenario: performance_optimized
 facts:
   - name: exclude_package_sbd
     gatherer: package_version@v1

--- a/checks/C620DC.yaml
+++ b/checks/C620DC.yaml
@@ -50,7 +50,7 @@ metadata:
   cluster_type: 
     - hana_scale_up
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_expected_votes
     gatherer: corosync.conf@v1

--- a/checks/CAEFF1.yaml
+++ b/checks/CAEFF1.yaml
@@ -42,7 +42,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: os_flavor
     gatherer: package_version@v1

--- a/checks/D028B9.yaml
+++ b/checks/D028B9.yaml
@@ -19,7 +19,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: compare_sles_sap_version
     gatherer: package_version@v1

--- a/checks/D78671.yaml
+++ b/checks/D78671.yaml
@@ -52,7 +52,7 @@ metadata:
   cluster_type: 
     - hana_scale_up
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: runtime_two_node
     gatherer: corosync-cmapctl@v1

--- a/checks/DA114A.yaml
+++ b/checks/DA114A.yaml
@@ -38,7 +38,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: corosync_nodes
     gatherer: corosync.conf@v1

--- a/checks/DC5429.yaml
+++ b/checks/DC5429.yaml
@@ -22,7 +22,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: compare_corosync_version
     gatherer: package_version@v1

--- a/checks/DE74B2.yaml
+++ b/checks/DE74B2.yaml
@@ -34,7 +34,7 @@ metadata:
     - hana_scale_out
     - ascs_ers
   provider: azure
-
+  hana_scenario: performance_optimized
 facts:
   - name: resources_primitives
     gatherer: cibadmin@v1

--- a/checks/DF8328.yaml
+++ b/checks/DF8328.yaml
@@ -21,7 +21,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: installed_corosync_version
     gatherer: package_version@v1

--- a/checks/F50AF5.yaml
+++ b/checks/F50AF5.yaml
@@ -19,7 +19,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: compare_python3_version
     gatherer: package_version@v1

--- a/checks/FB0E0D.yaml
+++ b/checks/FB0E0D.yaml
@@ -52,7 +52,7 @@ metadata:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-
+  hana_scenario: performance_optimized
 facts:
   - name: consensus_timeout
     gatherer: corosync-cmapctl@v1


### PR DESCRIPTION
# Description

This pr updates all existing checks by adding `hana_scenario: performance_optimized` to all existing hana_scale_up related checks. 
This change is required for the new hana scale up scenario discovery. 
Previously we only had hana scale up performance optimized checks,  with the discovery of the cost opt scenario in 
[#3206](https://github.com/trento-project/web/pull/3206) and [3152](https://github.com/trento-project/web/pull/3152). 

The new rule is like this:

When a check has a metadata  and a cluster_type property
```metadata:
  target_type: cluster  
  cluster_type: 
    - hana_scale_up
```
Check will be shown in a hana scale up cluster --> cost opt and performance opt scenario

When a check has a hana_scenario property in addition:
```
  cluster_type: 
    - hana_scale_up
  hana_scenario: cost_optimized
```
Check will be shown only in a hana scale up cost opt scenario.

When a a check has a hana_scenario  property
```
  cluster_type: 
    - hana_scale_up
  hana_scenario: performance_optimized
```
Check will be shown only in a hana scale up performance opt scenario.