### PR TITLE
bump BCI version to 15.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.6
 
 LABEL org.opencontainers.image.source="https://github.com/trento-project/checks"
 
 # If set to C, LC_ALL takes precedence
 ENV LC_ALL=C.UTF-8
-
-# tar is required by kubectl cp
-RUN zypper --non-interactive in -y tar && \
-    zypper --non-interactive clean
 
 RUN mkdir --mode=0600 /tmp/trento-checks-build
 

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -4,16 +4,12 @@
 #!BuildTag: trento/trento-checks:%%VERSION%%-build%RELEASE%
 #!UseOBSRepositories
 #!ExclusiveArch: x86_64
-FROM bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.6
 
 LABEL org.opencontainers.image.source="https://github.com/trento-project/checks"
 
 # If set to C, LC_ALL takes precedence
 ENV LC_ALL=C.UTF-8
-
-# tar is required by kubectl cp
-RUN zypper --non-interactive in -y tar && \
-    zypper --non-interactive clean
 
 RUN mkdir --mode=0600 /tmp/trento-checks-build
 


### PR DESCRIPTION
which no longer requires installing tar

this is also kinda related to https://github.com/trento-project/web/pull/3232