### PR TITLE
Versioning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,10 +174,15 @@ jobs:
           mv checks.dist checks
           tar -czf checks.tar.gz checks
           mv checks.orig checks
+      - name: Compute VERSION
+        id: version
+        run: echo "version=$(./hack/get_version_from_git.sh)" >> "$GITHUB_OUTPUT"
       - name: Build and Push Docker Image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true # Will only build if this is not here
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
           tags: |
             ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN install --directory --mode=0755 /usr/src/trento-checks
 RUN install --directory --mode=0755 /usr/src/trento-checks/checks
 RUN install --preserve-timestamps --mode=0644 ./checks/checks/* /usr/src/trento-checks/checks
 RUN install --preserve-timestamps --mode=0755 ./checks/bin/trento-install-checks /usr/bin/trento-install-checks
+RUN printf '%s\n' "${VERSION}" > /usr/src/trento-checks/checks/VERSION && chmod 0644 /usr/src/trento-checks/checks/VERSION
 
 WORKDIR /
 

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -47,6 +47,7 @@ RUN install --directory --mode=0755 /usr/src/trento-checks
 RUN install --directory --mode=0755 /usr/src/trento-checks/checks
 RUN install --preserve-timestamps --mode=0644 ./checks/checks/* /usr/src/trento-checks/checks
 RUN install --preserve-timestamps --mode=0755 ./checks/bin/trento-install-checks /usr/bin/trento-install-checks
+RUN printf '%s\n' "%%VERSION%%" > /usr/src/trento-checks/checks/VERSION && chmod 0644 /usr/src/trento-checks/checks/VERSION
 
 WORKDIR /
 

--- a/packaging/suse/rpm/trento-checks.spec
+++ b/packaging/suse/rpm/trento-checks.spec
@@ -43,6 +43,8 @@ BuildArch:      noarch
 install -d -m 0755 %{buildroot}%{trento_dir}
 install -d -m 0755 %{buildroot}%{trento_checks_dir}
 install -p -m 0644 checks/* %{buildroot}%{trento_checks_dir}
+echo "%{version}" > %{buildroot}%{trento_checks_dir}/VERSION
+chmod 0644 %{buildroot}%{trento_checks_dir}/VERSION
 
 %files
 %license LICENSE


### PR DESCRIPTION
Append a `VERSION` file at build time, so that when checks are mounted into `Wanda`, the check pack version can be inspected