### PR TITLE
[TRNT-4358] Add license headers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Check license Headers
@@ -36,6 +36,8 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/data
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run TLint
         run: "/home/tlint/tlint lint /data/checks"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,7 @@
-name: Continous Integration
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Continuous Integration
 
 on:
   push:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,7 @@ jobs:
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     uses: trento-project/.github/.github/workflows/obs-sync.yaml@406be0972195864a87ed454458eaa0856d0c5457 # v1.6.0
     needs:
+      - license-headers
       - tlint
     with:
       obs_project: ${{ vars.OBS_PROJECT_ROLLING }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  license-headers:
+    name: Ensure license headers are present and correct
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Check license Headers
+        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+
   tlint:
     name: Lint checks
     runs-on: ubuntu-24.04
@@ -25,18 +36,13 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/data
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
-        name: Check license headers
-
       - name: Run TLint
         run: "/home/tlint/tlint lint /data/checks"
 
   publish-containers:
     name: Publish GHCR Containers
     needs:
+      - license-headers
       - tlint
     if: >-
       github.event_name == 'push' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        name: Check license headers
+
       - name: Run TLint
         run: "/home/tlint/tlint lint /data/checks"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Release
 
 on:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: GPL-3.0-or-later
+    copyright-owner: SUSE LLC
+    software-name: trento-checks
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: GPL-3.0-or-later
+  paths-ignore:
+    - "**/*.adoc"
+    # - "**/*.example"
+    # - "**/*.json"
+    - "**/*.md"
+    # - "**/*.pem"
+    # - "**/*.service"
+    # - "**/*.svg"
+    # - "**/*.txt"
+    # - ".github/CODEOWNERS"
+    - ".github/dependabot.yml"
+    # - ".tool-versions"
+    # - "CHANGELOG.md"
+    - "LICENSE"
+    # - "VERSION"
+    # - "go.sum"
+    # - "bin/**"

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -12,18 +12,6 @@ header:
       SPDX-License-Identifier: GPL-3.0-or-later
   paths-ignore:
     - "**/*.adoc"
-    # - "**/*.example"
-    # - "**/*.json"
     - "**/*.md"
-    # - "**/*.pem"
-    # - "**/*.service"
-    # - "**/*.svg"
-    # - "**/*.txt"
-    # - ".github/CODEOWNERS"
     - ".github/dependabot.yml"
-    # - ".tool-versions"
-    # - "CHANGELOG.md"
     - "LICENSE"
-    # - "VERSION"
-    # - "go.sum"
-    # - "bin/**"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 ARG OS_VER=15.7
 FROM registry.suse.com/bci/bci-base:${OS_VER}
 ARG OS_VER

--- a/bin/trento-install-checks
+++ b/bin/trento-install-checks
@@ -1,5 +1,8 @@
 #!/bin/sh
 #
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
 #  trento-install-checks
 #
 #  This script installs the checks into the directory Wanda expects them.  It

--- a/checks/00081D.yaml
+++ b/checks/00081D.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "00081D"
 name: Check Corosync max_messages during runtime
 group: Corosync
@@ -48,11 +51,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/0AA227.yaml
+++ b/checks/0AA227.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "0AA227"
 name: Cluster priority-fencing-delay
 group: Pacemaker
@@ -48,7 +51,7 @@ facts:
 values:
   - name: priority_fencing_delay
     default: 30
-expectations:  
+expectations:
   - name: priority_fencing_delay
     expect: |
       if facts.cib_configuration.nodes.node.len != 2 { return true; } // only run on 2 node cluster

--- a/checks/0B0F87.yaml
+++ b/checks/0B0F87.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "0B0F87"
 name: SAPHanaSR version identical on all nodes
 group: OS and package versions
@@ -35,7 +38,7 @@ remediation: |
 metadata:
   target_type: cluster
   cluster_type: hana_scale_up
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
   architecture_type: classic

--- a/checks/0B2F82.yaml
+++ b/checks/0B2F82.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "0B2F82"
 name: SAPHanaSR-angi version identical on all nodes
 group: OS and package versions
@@ -14,7 +17,7 @@ remediation: |
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
   architecture_type: angi

--- a/checks/0B6DB2.yaml
+++ b/checks/0B6DB2.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "0B6DB2"
 name: SBD_PACEMAKER
 group: SBD
@@ -52,11 +55,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
   provider: [azure, nutanix, kvm, vmware]

--- a/checks/0D636F.yaml
+++ b/checks/0D636F.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "0D636F"
 name: ASCS Enqueue server restart is disabled - ENSA2
 group: SAP profiles
@@ -49,12 +52,12 @@ expectations:
         let inst = facts.cluster_sids[sid].instances.find(|inst| inst.name == `ASCS${inst.instance_number}`);
         if inst == () { return false; }
         let result = facts.sap_profiles[sid].profiles.find(|p| {
-          p.content.contains("INSTANCE_NAME") && 
+          p.content.contains("INSTANCE_NAME") &&
           p.content["INSTANCE_NAME"] == inst.name &&
           !p.content.contains("Restart_Program_01") && // check restart is disabled
           p.content.contains("Start_Program_01")       // check start is enabled
         });
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one enqueue server restart is enabled and has to be disabled.

--- a/checks/156F64.yaml
+++ b/checks/156F64.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "156F64"
 name: Check Corosync token_timeout value
 group: Corosync
@@ -49,11 +52,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/15F7A8.yaml
+++ b/checks/15F7A8.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "15F7A8"
 name: Check Corosync token_retransmits_before_loss_const during runtime
 group: Corosync
@@ -48,11 +51,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/1E91FF.yaml
+++ b/checks/1E91FF.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "1E91FF"
 name: ASCS instance MINIMAL_PROBE - simple_mount
 group: ASCS / ERS Cluster - cluster resources
@@ -54,12 +57,12 @@ facts:
 values:
   - name: resource_type
     default: ASCS
-expectations:  
+expectations:
   - name: resource_minimal_probe
     expect: |
       let sids = facts.cluster_sids.keys();
       for sid in sids {
-        let inst = facts.cluster_sids[sid].instances.find(|i| i.name == `${values.resource_type}${i.instance_number}`);        
+        let inst = facts.cluster_sids[sid].instances.find(|i| i.name == `${values.resource_type}${i.instance_number}`);
         if inst == () { return false; }
         if inst.filesystem_based { continue; } // skip instance if resource_managed
         let group = facts.cib_configuration.resources.group.find(|g| g.id == inst.resource_group);
@@ -70,5 +73,5 @@ expectations:
           .find(|nv| nv.name == "MINIMAL_PROBE" && nv.value == true);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} resource does not have MINIMAL_PROBE set to true in simple mount setup

--- a/checks/1F877F.yaml
+++ b/checks/1F877F.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "1F877F"
 name: users sidadm and sapadm
 group: OS users/groups
@@ -30,5 +33,5 @@ expectations:
         let result = facts.passwd.find(|u| u.user == sidadm);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: The sidadm user does not exist for every managed SID on all cluster nodes

--- a/checks/205AF7.yaml
+++ b/checks/205AF7.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "205AF7"
 name: fencing enabled
 group: Pacemaker
@@ -44,11 +47,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/21FCA6.yaml
+++ b/checks/21FCA6.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "21FCA6"
 name: Check Corosync token_retransmits_before_loss_const value
 group: Corosync
@@ -49,11 +52,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/222A57.yaml
+++ b/checks/222A57.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "222A57"
 name: supported sbd version
 group: OS and package versions
@@ -16,12 +19,12 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/24ABCB.yaml
+++ b/checks/24ABCB.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "24ABCB"
 name: Check Corosync join timeout value
 group: Corosync
@@ -44,11 +47,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/2A4BEE.yaml
+++ b/checks/2A4BEE.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "2A4BEE"
 name: susHanaSR/SAPHanaSR global.ini file configuration is properly done
 group: Ini Files
@@ -13,31 +16,31 @@ remediation: |
   ## References
   Azure:
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_3_saphanasr
-    
+
   AWS:
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-implementing-python-hook-saphanasr-in-sles.html
-  
+
   GCP:
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-1.10.11.4
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-1.10.11.4
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
-  architecture_type: 
+  architecture_type:
     - classic
     - angi
   hana_scenario:
     - performance_optimized
-    - cost_optimized 
+    - cost_optimized
 
 facts:
   - name: ini_files
@@ -51,25 +54,25 @@ values:
     default: "/usr/share/SAPHanaSR-angi/"
     conditions:
       - value: "/usr/share/SAPHanaSR/"
-        when: env.architecture_type == "classic"    
+        when: env.architecture_type == "classic"
   - name: path2
-    default: "/usr/share/SAPHanaSR-angi"    
+    default: "/usr/share/SAPHanaSR-angi"
     conditions:
       - value: "/usr/share/SAPHanaSR"
-        when: env.architecture_type == "classic"    
+        when: env.architecture_type == "classic"
   - name: provider
     customization_disabled: true
     default: "susHanaSR"
     conditions:
       - value: "SAPHanaSR"
-        when: env.architecture_type == "classic"    
+        when: env.architecture_type == "classic"
   - name: provider_text
     customization_disabled: true
     default: "ha_dr_provider_sushanasr"
     conditions:
       - value: "ha_dr_provider_saphanasr"
         when: env.architecture_type == "classic"
-    
+
 expectations:
   - name: expectations_sushanasr_global_ini_configured
     expect: |
@@ -80,5 +83,5 @@ expectations:
           if sushanasr.execution_order == values.execution_order && sushanasr.provider == values.provider {return true;}
         }
       }
-      return false;      
-    failure_message: SAPHanaSR section in global.ini is not correctly configured    
+      return false;
+    failure_message: SAPHanaSR section in global.ini is not correctly configured

--- a/checks/2A4BEF.yaml
+++ b/checks/2A4BEF.yaml
@@ -1,24 +1,27 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "2A4BEF"
 name: suschksrv global.ini file configuration is properly done
 group: Ini Files
 description: |
   suschksrv global.ini file configuration is properly done
 remediation: |
-  ## Abstract  
+  ## Abstract
   Purpose of suschksrv python hook is to detect failing HANA indexserver processes and trigger a fast  takeover to  the  secondary site. With regular configuration of an HANA database, the resource agent (RA) for HANA in a Linux cluster does not trigger a takeover to the secondary site when:
    - A software failure causes one or more HANA processes to be restarted in place by the  HANA  daemon (hdbdaemon).
    - A  hardware  error  (e.g.  SIGBUS  from  an uncorrectable memory error) causes the indexserver to restart locally.
-  
+
   ## Remediation
   Edit the global.ini configuration and make changes as per the best practice guide
-    
+
   ## References
   Azure:
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_3_saphanasr
-    
+
   AWS:
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-implementing-python-hook-saphanasr-in-sles.html
-      
+
   GCP:
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
 
@@ -71,4 +74,4 @@ expectations:
         if suschksrv.execution_order == values.execution_order && (suschksrv.path == values.path1 || suschksrv.path == values.path2) && suschksrv.provider == values.provider {return true;}
       }
       return false;
-    failure_message: suschksrv section in global.ini is not correctly configured  
+    failure_message: suschksrv section in global.ini is not correctly configured

--- a/checks/2A4BF0.yaml
+++ b/checks/2A4BF0.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "2A4BF0"
 name: sustkover global.ini file configuration is properly done
 group: Ini Files
@@ -6,20 +9,20 @@ description: |
 remediation: |
   ## Abstract
   sustkover python hook allows manual takeover of the HANA primary if the SAP HANA multi-state  resource  (managed  by  SAPHanaController) is set into maintenance or the Linux cluster is stopped.  Otherwise the manual takeover is blocked.
-                  
+
   ## Remediation
   Edit the global.ini configuration and make changes as per the best practice guide
 
   ## References
   Azure:
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_3_saphanasr
-    
+
   AWS:
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-implementing-python-hook-saphanasr-in-sles.html
-        
-  GCP:  
+
+  GCP:
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
-    
+
   SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-1.10.11.4
 

--- a/checks/2B37D1.yaml
+++ b/checks/2B37D1.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "2B37D1"
 name: Polkit rules for SAP instance systemd services
 group: Sapservices

--- a/checks/31ADCA.yaml
+++ b/checks/31ADCA.yaml
@@ -1,5 +1,8 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "31ADCA"
-name: supported SAPHanaSR-angi version 
+name: supported SAPHanaSR-angi version
 group: OS and package versions
 description: |
   SAPHanaSR-angi version is supported
@@ -12,7 +15,7 @@ remediation: |
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
   architecture_type: angi

--- a/checks/31BDCB.yaml
+++ b/checks/31BDCB.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "31BDCB"
 name: supported SAPHanaSR version
 group: OS and package versions
@@ -18,7 +21,7 @@ metadata:
   target_type: cluster
   cluster_type: hana_scale_up
   architecture_type: classic
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/32CFC6.yaml
+++ b/checks/32CFC6.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "32CFC6"
 name: corosync running 2 ring configuration
 group: Corosync
@@ -39,11 +42,11 @@ severity: warning
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/33403D.yaml
+++ b/checks/33403D.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "33403D"
 name: Check Corosync transport mechanism
 group: Corosync
@@ -67,11 +70,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/33B87B.yaml
+++ b/checks/33B87B.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "33B87B"
 name: supported supportutils-plugin-ha-sap version
 group: OS and package versions

--- a/checks/373DB8.yaml
+++ b/checks/373DB8.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "373DB8"
 name: fencing timeout
 group: Pacemaker
@@ -44,10 +47,10 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/3A361F.yaml
+++ b/checks/3A361F.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3A361F"
 name: Systemd system state is running
 group: saptune
@@ -34,7 +37,7 @@ expectations:
       let expected_systemd_state = ["running"];
       let warning_systemd_state = ["initializing", "starting", "maintenance", "stopping"];
 
-      if facts.saptune_status.result != () && 
+      if facts.saptune_status.result != () &&
          facts.saptune_status.result.systemd_system_state in expected_systemd_state {
         "passing"
       } else if facts.saptune_status.result != () &&

--- a/checks/3A59DC.yaml
+++ b/checks/3A59DC.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3A59DC"
 name: The recommended Solution is enabled
 group: saptune
@@ -42,7 +45,7 @@ expectations:
   - name: recommended_solution
     expect: |
       // handle custom solutions like 'HANA_mySol' too
-      let current_solution = 
+      let current_solution =
         if ! facts.saptune_status.result.solution_enabled.is_empty {
             facts.saptune_status.result.solution_enabled[0]
         } else {

--- a/checks/3A8663.yaml
+++ b/checks/3A8663.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3A8663"
 name: saptune is configured correctly service-wise
 group: saptune
@@ -37,7 +40,7 @@ expectations:
       if result.services.tuned == ["disabled", "inactive"] || result.services.tuned.is_empty {
          tuned_serv = true  // OK
       }
-    
+
       if  result.services.saptune == ["enabled", "active"] & sapconf_serv & tuned_serv {
          "passing"
       } else if result.services.saptune.contains("inactive") || ! sapconf_serv {

--- a/checks/3A9890.yaml
+++ b/checks/3A9890.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3A9890"
 name: saptune overrides are identical on all nodes
 group: saptune

--- a/checks/3AA324.yaml
+++ b/checks/3AA324.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3AA324"
 name: sapping/sappong enabled - simple_mount
 group: OS services
@@ -39,7 +42,7 @@ expectations:
       if (facts.cluster_sids.values().some(|sid| sid.instances.some(|instance| !instance.filesystem_based))) {
           return facts.service_sapping["unit_file_state"] == "enabled";
       }
-      return true;      
+      return true;
     failure_message: The sapping service is not enabled at boot time
   - name: sappong_enabled_on_simple_mount
     expect: |
@@ -47,5 +50,5 @@ expectations:
       if (facts.cluster_sids.values().some(|sid| sid.instances.some(|instance| !instance.filesystem_based))) {
           return facts.service_sappong["unit_file_state"] == "enabled";
       }
-      return true;      
+      return true;
     failure_message: The sappong service is not enabled at boot time

--- a/checks/3AA381.yaml
+++ b/checks/3AA381.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3AA381"
 name: The saptune package version is identical on all nodes
 group: saptune

--- a/checks/3AD734.yaml
+++ b/checks/3AD734.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3AD734"
 name: All nodes have the same Solution and Notes enabled
 group: saptune

--- a/checks/3ADBCB.yaml
+++ b/checks/3ADBCB.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3ADBCB"
 name: saptune does not report warnings
 group: saptune

--- a/checks/3ADE17.yaml
+++ b/checks/3ADE17.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3ADE17"
 name: The tuning of the system is compliant
 group: saptune

--- a/checks/3AF270.yaml
+++ b/checks/3AF270.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3AF270"
 name: All enabled Notes are also applied
 group: saptune

--- a/checks/3D8598.yaml
+++ b/checks/3D8598.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3D8598"
 name: Colocation constraint is correctly configured
 group: Pacemaker
@@ -14,30 +17,30 @@ remediation: |
   ## References
   Azure:
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_7_saphanasr
-    
+
   AWS:
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-constraints.html
-  
+
   GCP:
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
+
+  SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-constraints-for-saphanasr
-                  
-  Nutanix:        
+
+  Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-constraints-for-saphanasr
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
-  architecture_type: 
+  architecture_type:
     - classic
     - angi
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: constraints
@@ -45,7 +48,7 @@ facts:
     argument: cib.configuration.constraints
   - name: resources
     gatherer: cibadmin@v1
-    argument: cib.configuration.resources    
+    argument: cib.configuration.resources
 
 values:
   - name: col_rsc_role
@@ -96,5 +99,5 @@ expectations:
             }
           }
         }
-        facts.constraints.rsc_colocation.find(|col| (col["rsc"] == vip_prim || col["rsc"] == vip_grp ) && col["rsc-role"] == values.col_rsc_role && col["score"] == values.col_rsc_score && col["with-rsc"] == saphanasr_id && col["with-rsc-role"] == values.col_with_rsc_role) != ()      
+        facts.constraints.rsc_colocation.find(|col| (col["rsc"] == vip_prim || col["rsc"] == vip_grp ) && col["rsc-role"] == values.col_rsc_role && col["score"] == values.col_rsc_score && col["with-rsc"] == saphanasr_id && col["with-rsc-role"] == values.col_with_rsc_role) != ()
     failure_message: Colocation constraint is not correctly configured

--- a/checks/3D8599.yaml
+++ b/checks/3D8599.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3D8599"
 name: order constraint is correctly configured for scale-up perf-optimized cluster
 group: Pacemaker
@@ -83,4 +86,4 @@ expectations:
           if ord["first"] == cln_id && ord["kind"] == values.ord_kind && ord["then"] == msl_id { return true; }
 
           return false;
-    failure_message: order constraint is not correctly configured            
+    failure_message: order constraint is not correctly configured

--- a/checks/3EB4C0.yaml
+++ b/checks/3EB4C0.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "3EB4C0"
 name: SAPStartSrv resources - simple_mount
 group: ASCS / ERS Cluster - cluster resources
@@ -58,7 +61,7 @@ facts:
 values:
   - name: resource_type
     default: SAPStartSrv
-expectations:  
+expectations:
   - name: ascs_resource_in_group
     expect: |
       let sids = facts.cluster_sids.keys();
@@ -90,7 +93,7 @@ expectations:
           .find(|nv| nv.name == check_key && nv.value == check_value);
         if result != () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ASCS ${values.resource_type} resource found outside of resource group
   - name: ascs_resource_monitor_operation
     expect: |
@@ -144,7 +147,7 @@ expectations:
           .find(|nv| nv.name == check_key && nv.value == check_value);
         if result != () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ERS ${values.resource_type} resource found outside of resource group
   - name: ers_resource_monitor_operation
     expect: |

--- a/checks/438525.yaml
+++ b/checks/438525.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "438525"
 name: Cluster hostnames resolution
 group: Miscellaneous
@@ -42,11 +45,11 @@ severity: warning
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:
@@ -63,4 +66,3 @@ expectations:
       node_names.sort();
       node_names.map(|node_name| facts.hosts[node_name]);
     failure_message: /etc/hosts file is missing some of the cluster nodes
-      

--- a/checks/442182.yaml
+++ b/checks/442182.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "442182"
 name: supported patterns-sap-nw version
 group: OS and package versions

--- a/checks/481552.yaml
+++ b/checks/481552.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "481552"
 name: hana_call_timeout
 group: Pacemaker
@@ -34,15 +37,15 @@ remediation: |
 severity: warning
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
-  architecture_type: 
+  architecture_type:
     - angi
     - classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized    
+    - cost_optimized
 
 facts:
   - name: resources
@@ -51,7 +54,7 @@ facts:
 
 values:
   - name: expected_hana_call_timeout
-    default: 60      
+    default: 60
 
 expectations:
   - name: expectations_hana_call

--- a/checks/48EEDC.yaml
+++ b/checks/48EEDC.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "48EEDC"
 name: supported sap_suse_cluster_connector version
 group: OS and package versions

--- a/checks/49591F.yaml
+++ b/checks/49591F.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "49591F"
 name: sbd SBD_STARTMODE
 group: SBD
@@ -49,12 +52,12 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/4DD3B5.yaml
+++ b/checks/4DD3B5.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "4DD3B5"
 name: ASCS and ERS location - ENSA1
 group: ASCS / ERS Cluster - cluster resources
@@ -20,22 +23,22 @@ remediation: |
   ## References
 
   Azure:
-    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers    
+    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers
 
   AWS:
-    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers    
+    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers
 
   GCP:
-    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers    
+    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers
 
   Nutanix:
-    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers    
+    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers
 
   SUSE / KVM:
-    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers    
+    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers
 
   VMware:
-    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers    
+    - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers
 metadata:
   target_type: cluster
   cluster_type: ascs_ers
@@ -51,7 +54,7 @@ facts:
 values:
   - name: location_score
     default: 2000
-expectations:  
+expectations:
   - name: location_ascs_ers_exists
     expect: |
       let sids = facts.cluster_sids.keys();
@@ -69,5 +72,5 @@ expectations:
             l.rule.score == values.location_score);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one Location constraint for this ENSA1 ASCS/ERS setup is not configured correctly with the score ${values.location_score}

--- a/checks/53D035.yaml
+++ b/checks/53D035.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "53D035"
 name: Check Corosync token timeout during runtime
 group: Corosync
@@ -50,11 +53,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/53D33E.yaml
+++ b/checks/53D33E.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "53D33E"
 name: sbd version identical on all nodes
 group: OS and package versions
@@ -17,11 +20,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
   provider: [azure, nutanix, kvm, vmware]

--- a/checks/553B84.yaml
+++ b/checks/553B84.yaml
@@ -1,8 +1,11 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "553B84"
 name: SAPHanaTopology resource is configured
 group: Pacemaker
 description: |
-  SAPHanaTopology resource is configured and with correct provider i.e. SUSE 
+  SAPHanaTopology resource is configured and with correct provider i.e. SUSE
 remediation: |
   ## Abstract
   This Trento check verified if SAPHanaTopoloy resource is configured and not missing. It also checks whether the RA provider is SUSE and not say for example heartbeat or anything else.
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphanatopology.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -62,8 +65,8 @@ expectations:
           for cln in hana_ct {
             let rsc = cln.primitive;
             for prim in rsc {
-              if prim.provider == values.resource_provider && prim.type == values.resource_type {return true;}                  
+              if prim.provider == values.resource_provider && prim.type == values.resource_type {return true;}
             }
           }
-          return false;          
+          return false;
     failure_message: SAPHanaTopology resource is not correctly configured

--- a/checks/553B85.yaml
+++ b/checks/553B85.yaml
@@ -1,11 +1,14 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "553B85"
 name: SAPHanaTopology resource has monitor timeout correctly configured
 group: Pacemaker
 description: |
-  SAPHanaTopology resource has monitor timeout correctly configured 
+  SAPHanaTopology resource has monitor timeout correctly configured
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHanaTopoloy resource has monitor timeout correctly configured and the configuration is not missing. 
+  This Trento check verified if SAPHanaTopoloy resource has monitor timeout correctly configured and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphanatopology.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.timeout == values.monitor_timeout {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHanaTopology resource has monitor timeout not correctly configured

--- a/checks/553B86.yaml
+++ b/checks/553B86.yaml
@@ -1,11 +1,14 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "553B86"
 name: SAPHanaTopology resource has start timeout correctly configured
 group: Pacemaker
 description: |
-  SAPHanaTopology resource has start timeout correctly configured 
+  SAPHanaTopology resource has start timeout correctly configured
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHanaTopoloy resource has start timeout correctly configured and the configuration is not missing. 
+  This Trento check verified if SAPHanaTopoloy resource has start timeout correctly configured and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphanatopology.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.timeout == values.start_timeout {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHanaTopology resource has start timeout  not correctly configured

--- a/checks/553B87.yaml
+++ b/checks/553B87.yaml
@@ -1,11 +1,14 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "553B87"
 name: SAPHanaTopology resource has stop timeout correctly configured
 group: Pacemaker
 description: |
-  SAPHanaTopology resource has stop timeout correctly configured 
+  SAPHanaTopology resource has stop timeout correctly configured
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHanaTopoloy resource has stop timeout correctly configured and the configuration is not missing. 
+  This Trento check verified if SAPHanaTopoloy resource has stop timeout correctly configured and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphanatopology.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.timeout == values.stop_timeout {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHanaTopology resource has stop timeout  not correctly configured

--- a/checks/553B88.yaml
+++ b/checks/553B88.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "553B88"
 name: SAPHanaTopology clone resource has clone-node-max correctly configured
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   SAPHanaTopology clone resource has clone-node-max correctly configured
 remediation: |
   ## Abstract
-  SAPHanaTopology clone resource has clone-node-max correctly configured and not missing. 
+  SAPHanaTopology clone resource has clone-node-max correctly configured and not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_6_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -62,5 +65,5 @@ expectations:
                 if cnx.value == values.clone_node_max {return true};
               }
             }
-          return false;          
+          return false;
     failure_message: SAPHanaTopology clone resource has clone-node-max not correctly configured

--- a/checks/553B89.yaml
+++ b/checks/553B89.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "553B89"
 name: SAPHanaTopology clone resource has interleave correctly configured
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   SAPHanaTopology clone resource has interleave correctly configured
 remediation: |
   ## Abstract
-  SAPHanaTopology clone resource has interleave correctly configured and not missing. 
+  SAPHanaTopology clone resource has interleave correctly configured and not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_6_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -62,5 +65,5 @@ expectations:
                 if cnx.value == values.interleave {return true};
               }
             }
-          return false;          
+          return false;
     failure_message: SAPHana multi-state resource has interleave not correctly configured

--- a/checks/553B8A.yaml
+++ b/checks/553B8A.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "553B8A"
 name: SAPHanaTopology resource has monitor interval correctly configured
 group: Pacemaker
@@ -6,20 +9,20 @@ description: |
 remediation: |
   ## Abstract
   Monitor interval of a resource defines how often the monitor operation will run for that resources. For example an interval of 10 seconds means that the monitor operation will run every 10 seconds for that resource.
-  
+
   ## Remediation
   Edit the crm configuration and make changes as per the best practice guide
 
   ## References
   Azure:
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphanatopology.html
-  
+
   GCP:
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-  
+
   SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
@@ -87,4 +90,4 @@ expectations:
 
       if SAPHanaTopo_interval == values.monitor_interval && SAPHanaTopo_interval < SAPHana_interval { return true; }
       return false;
-    failure_message: SAPHanaTopology resource has monitor interval not correctly configured            
+    failure_message: SAPHanaTopology resource has monitor interval not correctly configured

--- a/checks/57C663.yaml
+++ b/checks/57C663.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "57C663"
 name: ASCS instance resource-stickiness
 group: ASCS / ERS Cluster - cluster resources
@@ -49,7 +52,7 @@ values:
     default: 5000
   - name: resource_type
     default: ASCS
-expectations:  
+expectations:
   - name: ascs_resource_resource_stickiness
     expect: |
       let sids = facts.cluster_sids.keys();

--- a/checks/58002B.yaml
+++ b/checks/58002B.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "58002B"
 name: ASCS and ERS order
 group: ASCS / ERS Cluster - cluster resources
@@ -11,7 +14,7 @@ remediation: |
   Correct the ASCS and ERS order constraint according to the best practices.
 
   ```
-  crm configure show ord_sap_NW1_first_start_ascs 
+  crm configure show ord_sap_NW1_first_start_ascs
   order ord_sap_NW1_first_start_ascs \
     Optional: rsc_sap_NW1_ASCS00:start rsc_sap_NW1_ERS10:stop symmetrical=false
   ```
@@ -48,7 +51,7 @@ facts:
     gatherer: cibadmin@v1
     argument: cib.configuration
 
-expectations:  
+expectations:
   - name: order_ascs_ers
     expect: |
       let sids = facts.cluster_sids.keys();

--- a/checks/5B7C59.yaml
+++ b/checks/5B7C59.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "5B7C59"
 name: sidadm and root are in sapinst
 group: OS users/groups

--- a/checks/610C10.yaml
+++ b/checks/610C10.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "610C10"
 name: azure-lb resource is configured
 group: Pacemaker
@@ -5,24 +8,24 @@ description: |
   azure-lb resource is configured
 remediation: |
   ## Abstract
-  azure-lb resource is needed for directing network traffic to correct virtual machine where the virtual IP is configured. 
+  azure-lb resource is needed for directing network traffic to correct virtual machine where the virtual IP is configured.
 
   ## Remediation
   Edit the crm configuration and make changes as per the best practice guide
-  
+
   ## References
   Azure:
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_7_saphanasr
-    
+
 customization_disabled: true
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type:   
+  cluster_type:
     - hana_scale_up
     - hana_scale_up
-  architecture_type: 
-    - classic 
+  architecture_type:
+    - classic
     - angi
 
   provider: azure
@@ -59,4 +62,4 @@ expectations:
             }
             }
           return false;
-    failure_message: azure-lb resource is not correctly configured            
+    failure_message: azure-lb resource is not correctly configured

--- a/checks/61451E.yaml
+++ b/checks/61451E.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "61451E"
 name: multiple SBD devices
 group: SBD
@@ -34,11 +37,11 @@ severity: warning
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
   provider: [azure, nutanix, kvm, vmware]

--- a/checks/62A0E0.yaml
+++ b/checks/62A0E0.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "62A0E0"
 name: ERS instance MINIMAL_PROBE - simple_mount
 group: ASCS / ERS Cluster - cluster resources
@@ -54,12 +57,12 @@ facts:
 values:
   - name: resource_type
     default: ERS
-expectations:  
+expectations:
   - name: resource_minimal_probe
     expect: |
       let sids = facts.cluster_sids.keys();
       for sid in sids {
-        let inst = facts.cluster_sids[sid].instances.find(|i| i.name == `${values.resource_type}${i.instance_number}`);        
+        let inst = facts.cluster_sids[sid].instances.find(|i| i.name == `${values.resource_type}${i.instance_number}`);
         if inst == () { return false; }
         if inst.filesystem_based { continue; } // skip instance if resource_managed
         let group = facts.cib_configuration.resources.group.find(|g| g.id == inst.resource_group);
@@ -70,5 +73,5 @@ expectations:
           .find(|nv| nv.name == "MINIMAL_PROBE" && nv.value == true);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} resource does not have MINIMAL_PROBE set to true in simple mount setup

--- a/checks/68626E.yaml
+++ b/checks/68626E.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "68626E"
 name: SBD msgwait timeout
 group: SBD
@@ -35,11 +38,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
   provider: [azure, nutanix, kvm, vmware]

--- a/checks/6B1B58.yaml
+++ b/checks/6B1B58.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "6B1B58"
 name: ASCS group resource-stickiness
 group: ASCS / ERS Cluster - cluster resources
@@ -48,12 +51,12 @@ values:
     default: 3000
   - name: resource_type
     default: ASCS
-expectations:  
+expectations:
   - name: group_resource_stickiness
     expect: |
       let sids = facts.cluster_sids.keys();
       for sid in sids {
-        let inst = facts.cluster_sids[sid].instances.find(|i| i.name == `${values.resource_type}${i.instance_number}`);        
+        let inst = facts.cluster_sids[sid].instances.find(|i| i.name == `${values.resource_type}${i.instance_number}`);
         if inst == () { return false; }
         let group = facts.cib_configuration.resources.group.find(|g| g.id == inst.resource_group && g.contains("meta_attributes"));
         if group == () { return false; }
@@ -61,5 +64,5 @@ expectations:
           .find(|nv| nv.name == "resource-stickiness" && nv.value == values.resource_stickiness_group);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} group does not have correct resource-stickiness of ${values.resource_stickiness_group}

--- a/checks/6E0DEC.yaml
+++ b/checks/6E0DEC.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "6E0DEC"
 name: Concurrent fencing option is enabled
 group: Azure Fence Agent
@@ -21,11 +24,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
   provider: azure

--- a/checks/6E6395.yaml
+++ b/checks/6E6395.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "6E6395"
 name: HA interface is active
 group: Sapcontrol
@@ -10,10 +13,10 @@ remediation: |
 
   ## Remediation
   Above problem could happen due to several reasons. E.g.
-  
+
     1. The <SID>adm user in not part of haclient group.
     2. The cluster use ACL to control access and haclient doesn't have the needed rights.
-    3. The ASCS/ERS resource contains wrong parameters. 
+    3. The ASCS/ERS resource contains wrong parameters.
     4. The ownership of the <SID>adm user /home/<SID>adm/.config directory is not set correctly to <SID>adm:sapsys.
     5. On SLE15 SP5 the packages crmsh and crmsh-scripts are not on the latest patch level and should have at least version crmsh-4.4.0+20221028.3e41444-150400.3.9.1
     6. /var/lib/heartbeat/cores/hacluster directory needs group read/execute permission (chmod 750 /var/lib/heartbeat/cores/hacluster)
@@ -61,7 +64,7 @@ expectations:
   - name: ha_active_true
     expect: |
       for sid in facts.cluster_sids.keys() {
-        if !facts.ha_get_failover_config.contains(sid) || 
+        if !facts.ha_get_failover_config.contains(sid) ||
           !facts.ha_get_failover_config[sid].all(|i| i.output.ha_active) { return false; }
       }
       return true;

--- a/checks/6E9B82.yaml
+++ b/checks/6E9B82.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "6E9B82"
 name: Check Corosync two_node value
 group: Corosync
@@ -48,10 +51,10 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:
@@ -81,10 +84,10 @@ expectations:
 
   - name: twonode_parameter
     expect: |
-     if facts.corosync_num_nodes.len == 2 { 
-       facts.corosync_twonode == values.expected_twonode 
-     } else if facts.corosync_num_nodes.len >= 3 { 
-       facts.corosync_twonode == values.expected_threeormore 
+     if facts.corosync_num_nodes.len == 2 {
+       facts.corosync_twonode == values.expected_twonode
+     } else if facts.corosync_num_nodes.len >= 3 {
+       facts.corosync_twonode == values.expected_threeormore
      } else {
        false
      }

--- a/checks/733ED3.yaml
+++ b/checks/733ED3.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "733ED3"
 name: ASCS and ERS colocation
 group: ASCS / ERS Cluster - cluster resources
@@ -11,13 +14,13 @@ remediation: |
   Correct the ASCS and ERS colocation constraint according to the best practices.
 
   ```
-  crm configure show col_sap_NW1_not_both 
-  
+  crm configure show col_sap_NW1_not_both
+
   colocation col_sap_NW1_not_both -5000: grp_NW1_ERS10 grp_NW1_ASCS00
   ```
 
   ## References
-  - ENSA1: https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers    
+  - ENSA1: https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers
   - ENSA2: https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-configuring-the-colocation-constraints-between-ascs-and-ers
 
 metadata:
@@ -32,12 +35,12 @@ facts:
 values:
   - name: colocation_score
     default: -5000
-expectations:  
+expectations:
   - name: colocation_ascs_ers
     expect: |
       let sids = facts.cluster_sids.keys();
       if !facts.cib_configuration.contains("constraints") { return false; } // a colocation is expected
-      if !facts.cib_configuration.constraints.contains("rsc_colocation") { return false; } // a colocation is expected      
+      if !facts.cib_configuration.constraints.contains("rsc_colocation") { return false; } // a colocation is expected
       for sid in sids {
         let group_ascs = facts.cluster_sids[sid].instances.find(|i| i.name == `ASCS${i.instance_number}` ).resource_group;
         if group_ascs == () { return false; } // without an ASCS group we cannot check colocation
@@ -47,5 +50,5 @@ expectations:
           .find(|c| c.rsc == group_ers && c["with-rsc"] == group_ascs && c.score == values.colocation_score);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one colocation to separate ASCS and ERS is not configured correctly with the score ${values.colocation_score}

--- a/checks/73BB51.yaml
+++ b/checks/73BB51.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "73BB51"
 name: sidadm is in sapsys
 group: OS users/groups
@@ -28,5 +31,5 @@ expectations:
         let result = group.users.contains(sidadm);
         if result == false { return false; }
       }
-      return true;      
+      return true;
     failure_message: The sidadm user is not in the sapsys group for every managed SID on all cluster nodes

--- a/checks/790926.yaml
+++ b/checks/790926.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "790926"
 name: hacluster password
 group: Miscellaneous
@@ -39,11 +42,11 @@ severity: warning
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/7E0221.yaml
+++ b/checks/7E0221.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "7E0221"
 name: Check Corosync transport settings during runtime
 group: Corosync
@@ -69,11 +72,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/7E7F18.yaml
+++ b/checks/7E7F18.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "7E7F18"
 name: IPaddr2 resources
 group: ASCS / ERS Cluster - cluster resources
@@ -12,13 +15,13 @@ remediation: |
 
   ```
   crm configure show rsc_ip_NW1_ASCS00
-  
+
   primitive rsc_ip_NW1_ASCS00 IPaddr2 \
     params ip=X.X.X.X cidr_netmask=24 nic=ethX \
     op monitor interval=10s timeout=20s
 
   crm configure show rsc_ip_NW1_ERS10
-  
+
   primitive rsc_ip_NW1_ERS10 IPaddr2 \
     params ip=X.X.X.X cidr_netmask=24 nic=ethX \
     op monitor interval=10s timeout=20s
@@ -78,7 +81,7 @@ facts:
 values:
   - name: resource_type
     default: IPaddr2
-expectations:  
+expectations:
   - name: ascs_resource_in_group
     expect: |
       let sids = facts.cluster_sids.keys();

--- a/checks/801E6A.yaml
+++ b/checks/801E6A.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "801E6A"
 name: supported sapstartsrv-resource-agents version
 group: OS and package versions

--- a/checks/802D5D.yaml
+++ b/checks/802D5D.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "802D5D"
 name: ASCS and ERS Filesystem resources - resource_managed
 group: ASCS / ERS Cluster - cluster resources
@@ -11,7 +14,7 @@ remediation: |
   Create the missing filesystem resources.
 
   ```
-  crm configure show rsc_fs_NW1_ASCS00 
+  crm configure show rsc_fs_NW1_ASCS00
 
   primitive rsc_fs_NW1_ASCS00 Filesystem \
   	params device="..." directory="/usr/sap/NW1/ASCS00" fstype=xfs \
@@ -19,7 +22,7 @@ remediation: |
   	op stop timeout=60s interval=0 \
   	op monitor interval=20s timeout=40s
 
-  crm configure show rsc_fs_NW1_ERS10 
+  crm configure show rsc_fs_NW1_ERS10
 
   primitive rsc_fs_NW1_ERS10 Filesystem \
   	params device="..." directory="/usr/sap/NW1/ERS10" fstype=xfs \
@@ -84,7 +87,7 @@ facts:
 values:
   - name: resource_type
     default: Filesystem
-expectations:  
+expectations:
   ## check will always return true if no fs resource is found due to the way the gatherer sets `filesystem_based`
   - name: ascs_resource_in_group
     expect: |
@@ -117,7 +120,7 @@ expectations:
           .find(|nv| nv.name == check_key && nv.value == check_value);
         if result != () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ASCS ${values.resource_type} resource found outside of resource group
   ## check will always return true if no fs resource is found due to the way the gatherer sets `filesystem_based`
   - name: ers_resource_in_group
@@ -151,5 +154,5 @@ expectations:
           .find(|nv| nv.name == check_key && nv.value == check_value);
         if result != () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ERS ${values.resource_type} resource found outside of resource group

--- a/checks/805CA4.yaml
+++ b/checks/805CA4.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "805CA4"
 name: simple mount fstab entries
 group: Filesystems

--- a/checks/810D2E.yaml
+++ b/checks/810D2E.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "810D2E"
 name: ASCS and ERS instance profiles load HA script connector
 group: SAP profiles
@@ -49,16 +52,16 @@ expectations:
         let inst = facts.cluster_sids[sid].instances.find(|inst| inst.name == `ASCS${inst.instance_number}`);
         if inst == () { return false; }
         let result = facts.sap_profiles[sid].profiles.find(|p| {
-          p.content.contains("INSTANCE_NAME") && 
+          p.content.contains("INSTANCE_NAME") &&
           p.content["INSTANCE_NAME"] == inst.name &&
           p.content.contains("service/halib") &&
           p.content["service/halib"] == "$(DIR_CT_RUN)/saphascriptco.so" &&
           p.content.contains("service/halib_cluster_connector") &&
-          p.content["service/halib_cluster_connector"] == "/usr/bin/sap_suse_cluster_connector";            
+          p.content["service/halib_cluster_connector"] == "/usr/bin/sap_suse_cluster_connector";
         });
-        if result == () { return false; }    
+        if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least for one SID the HA script connectors are not loaded correctly inside the ASCS instance profile
   - name: ers_halib_enabled
     expect: |
@@ -67,14 +70,14 @@ expectations:
         let inst = facts.cluster_sids[sid].instances.find(|inst| inst.name == `ERS${inst.instance_number}`);
         if inst == () { return false; }
         let result = facts.sap_profiles[sid].profiles.find(|p| {
-          p.content.contains("INSTANCE_NAME") && 
+          p.content.contains("INSTANCE_NAME") &&
           p.content["INSTANCE_NAME"] == inst.name &&
           p.content.contains("service/halib") &&
           p.content["service/halib"] == "$(DIR_CT_RUN)/saphascriptco.so" &&
           p.content.contains("service/halib_cluster_connector") &&
-          p.content["service/halib_cluster_connector"] == "/usr/bin/sap_suse_cluster_connector";            
+          p.content["service/halib_cluster_connector"] == "/usr/bin/sap_suse_cluster_connector";
         });
-        if result == () { return false; }    
+        if result == () { return false; }
       }
       return true;
     failure_message: At least for one SID the HA script connectors are not loaded correctly inside the ERS instance profile

--- a/checks/816815.yaml
+++ b/checks/816815.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "816815"
 name: SBD service state
 group: SBD
@@ -33,12 +36,12 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/822E47.yaml
+++ b/checks/822E47.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "822E47"
 name: Check Corosync join timeout during runtime
 group: Corosync
@@ -48,11 +51,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/82A031.yaml
+++ b/checks/82A031.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "82A031"
 name: pacemaker version identical on all nodes
 group: OS and package versions
@@ -17,11 +20,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/83952D.yaml
+++ b/checks/83952D.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "83952D"
 name: ERS group order - simple_mount
 group: ASCS / ERS Cluster - cluster resources
@@ -69,7 +72,7 @@ values:
           - IPaddr2
           - SAPStartSrv
           - SAPInstance
-expectations:  
+expectations:
   - name: check_group_order
     expect: |
       for sid in facts.cluster_sids.keys() {
@@ -81,5 +84,5 @@ expectations:
           let found_types = group.primitive.map(|p| p.type);
           if found_types != values.resource_order { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} group has wrong resource order, correct order would be ${values.resource_order}

--- a/checks/845CC9.yaml
+++ b/checks/845CC9.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "845CC9"
 name: Check Corosync max_messages value
 group: Corosync
@@ -49,11 +52,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/87EE50.yaml
+++ b/checks/87EE50.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "87EE50"
 name: supported systemd version
 group: OS and package versions
@@ -16,7 +19,7 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: ascs_ers  
+  cluster_type: ascs_ers
 
 facts:
   - name: compare_systemd

--- a/checks/8D5080.yaml
+++ b/checks/8D5080.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "8D5080"
 name: ERS group order - resource_managed
 group: ASCS / ERS Cluster - cluster resources
@@ -69,7 +72,7 @@ values:
           - anything
           - IPaddr2
           - SAPInstance
-expectations:  
+expectations:
   - name: check_group_order
     expect: |
       for sid in facts.cluster_sids.keys() {
@@ -81,5 +84,5 @@ expectations:
           let found_types = group.primitive.map(|p| p.type);
           if found_types != values.resource_order { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} group has wrong resource order, correct order would be ${values.resource_order}

--- a/checks/8E6110.yaml
+++ b/checks/8E6110.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "8E6110"
 name: saphostagent enabled and started
 group: Saphostagent

--- a/checks/8F6362.yaml
+++ b/checks/8F6362.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "8F6362"
 name: Sudoers entry for crm_attribute command is correctly configured
 group: Sudoers
@@ -23,7 +26,7 @@ remediation: |
   SUSE / KVM /Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-allowing-sidadm-to-access-the-cluster
 
-customization_disabled: true    
+customization_disabled: true
 severity: critical
 metadata:
   target_type: cluster
@@ -80,4 +83,4 @@ expectations:
           }
       }
       return false;
-    failure_message: sudoers entry for command crm_attribute is not correctly configured          
+    failure_message: sudoers entry for command crm_attribute is not correctly configured

--- a/checks/8F6363.yaml
+++ b/checks/8F6363.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "8F6363"
 name: Sudoers entry for SAPHanaSR-hookHelper command is correctly configured for susTkOver Hook
 group: Sudoers
@@ -74,5 +77,5 @@ expectations:
           else if words[1] == "--sid\\="+SID && (words[2] == "*" || words[2] == "--case\\="+values.case1) { return true; }
         }
       }
-      return false;      
+      return false;
     failure_message: sudoers entry for command SAPHanaSR-hookHelper is not correctly configured for susTakeOver Hook

--- a/checks/95B405.yaml
+++ b/checks/95B405.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "95B405"
 name: Instance Status
 group: Sapcontrol
@@ -26,7 +29,7 @@ expectations:
   - name: instance_status_green
     expect: |
       for sid in facts.cluster_sids.keys() {
-        if !facts.system_instance_list.contains(sid) || 
+        if !facts.system_instance_list.contains(sid) ||
           !facts.system_instance_list[sid].all(|inst| inst.output.all(|o| o.dispstatus == values.expected_instance_status)) {
             return false;
         }

--- a/checks/972BE0.yaml
+++ b/checks/972BE0.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "972BE0"
 name: ASCS and ERS instance autostart disabled
 group: OS services
@@ -39,5 +42,5 @@ expectations:
               }
           }
       }
-      return true;      
+      return true;
     failure_message: ASCS or ERS systemd services are not disabled at boot time for a clustered SAP instance

--- a/checks/979BF8.yaml
+++ b/checks/979BF8.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "979BF8"
 name: Sapservices start with systemd or SysVinit
 group: Sapservices

--- a/checks/97E22D.yaml.wip
+++ b/checks/97E22D.yaml.wip
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "97E22D"
 name: ASCS and ERS virtual hostnames are reachable
 group: OS services
@@ -21,7 +24,7 @@ expectations:
     expect: |
       let sids = facts.cluster_sids.keys();
       for sid in sids {
-          for inst in facts.cluster_sids[sid].instances { 
+          for inst in facts.cluster_sids[sid].instances {
               if ! facts.sapinstance_hostname_resolver[sid]
                       .find(|i| i.instance_name == inst.name)
                       .reachability {

--- a/checks/9C304A.yaml
+++ b/checks/9C304A.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "9C304A"
 name: sidadm is in haclient
 group: OS users/groups
@@ -28,5 +31,5 @@ expectations:
         let result = group.users.contains(sidadm);
         if result == false { return false; }
       }
-      return true;      
+      return true;
     failure_message: The sidadm user is not in the haclient group for every managed SID on all cluster nodes

--- a/checks/9C7296.yaml
+++ b/checks/9C7296.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "9C7296"
 name: SAP Kernel supports systemd
 group: SAP Kernel

--- a/checks/9CFD28.yaml
+++ b/checks/9CFD28.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "9CFD28"
 name: Virtual IP resource is configured
 group: Pacemaker
@@ -9,19 +12,19 @@ remediation: |
 
   ## Remediation
   Edit the crm configuration and make changes as per the best practice guide
-  
+
   ## References
   Azure:
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_7_saphanasr
-    
+
   AWS:
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-move-the-ip-resource.html
       ## AWS have different resource agent for virtual IP and different values for interval and timeout for monitor operation for virtual IP resource configured
-          
-  GCP:    
+
+  GCP:
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
       ## GCP have same resource agent IPaddr2 but different value for interval and timeout for monitor operations.
-                  
+
   SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-adding-a-virtual-ip-address-for-the-primary-site
 
@@ -76,4 +79,4 @@ expectations:
             }
             }
           return false;
-    failure_message: virtual IP resource is not correctly configured                  
+    failure_message: virtual IP resource is not correctly configured

--- a/checks/9CFD29.yaml
+++ b/checks/9CFD29.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "9CFD29"
 name: virtual IP resource has monitor interval properly configured
 group: Pacemaker
@@ -80,4 +83,4 @@ expectations:
             }
           }
           return false;
-    failure_message: virtual IP resource has monitor interval not correctly configured                  
+    failure_message: virtual IP resource has monitor interval not correctly configured

--- a/checks/9CFD2A.yaml
+++ b/checks/9CFD2A.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "9CFD2A"
 name: Virtual IP resource has monitor timeout properly configured
 group: Pacemaker
@@ -80,4 +83,4 @@ expectations:
             }
           }
           return false;
-    failure_message: virtual IP resource has monitor timeout not correctly configured                
+    failure_message: virtual IP resource has monitor timeout not correctly configured

--- a/checks/9FAAD0.yaml
+++ b/checks/9FAAD0.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "9FAAD0"
 name: unsupported pacemaker version
 group: OS and package versions
@@ -13,11 +16,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/9FEFB0.yaml
+++ b/checks/9FEFB0.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "9FEFB0"
 name: supported pacemaker version
 group: OS and package versions
@@ -15,11 +18,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/A1244C.yaml
+++ b/checks/A1244C.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "A1244C"
 name: Check Corosync consensus timeout
 group: Corosync
@@ -49,11 +52,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/A8196A.yaml
+++ b/checks/A8196A.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "A8196A"
 name: HA interface Config Check
 group: Sapcontrol
@@ -10,10 +13,10 @@ remediation: |
 
   ## Remediation
   Above problem could happen due to several reasons. E.g.
-  
+
     1. The <SID>adm user in not part of haclient group.
     2. The cluster use ACL to control access and haclient doesn't have the needed rights.
-    3. The ASCS/ERS resource contains wrong parameters. 
+    3. The ASCS/ERS resource contains wrong parameters.
     4. The ownership of the <SID>adm user /home/<SID>adm/.config directory is not set correctly to <SID>adm:sapsys.
     5. On SLE15 SP5 the packages crmsh and crmsh-scripts are not on the latest patch level and should have at least version crmsh-4.4.0+20221028.3e41444-150400.3.9.1
     6. /var/lib/heartbeat/cores/hacluster directory needs group read/execute permission (chmod 750 /var/lib/heartbeat/cores/hacluster)
@@ -64,7 +67,7 @@ expectations:
   - name: ha_check_config_success
     expect: |
       for sid in facts.cluster_sids.keys() {
-        if !facts.ha_check_config.contains(sid) || 
+        if !facts.ha_check_config.contains(sid) ||
            !facts.ha_check_config[sid].all(|inst| inst.output.all(|o| o.state == values.expected_ha_check_config)) {
              return false;
         }

--- a/checks/ABA3CA.yaml
+++ b/checks/ABA3CA.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "ABA3CA"
 name: SAP Host Agent is running
 group: OS and package versions
@@ -38,11 +41,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/AC9724.yaml
+++ b/checks/AC9724.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AC9724"
 name: Sapservices contain all clustered instances
 group: Sapservices

--- a/checks/AE0C5F.yaml
+++ b/checks/AE0C5F.yaml
@@ -1,8 +1,11 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C5F"
 name: SAPHana resource is configured
 group: Pacemaker
 description: |
-  SAPHana resource is configured and with correct provider i.e. SUSE 
+  SAPHana resource is configured and with correct provider i.e. SUSE
 remediation: |
   ## Abstract
   This Trento check verified if SAPHana resource is configured and not missing. It also checks whether the RA provider is SUSE and not say for example heartbeat or anything else.
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_6_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -62,8 +65,8 @@ expectations:
           for cln in hana_ct {
             let msl = cln.primitive;
             for prim in msl {
-              if prim.provider == values.resource_provider && prim.type == values.resource_type {return true;}                  
+              if prim.provider == values.resource_provider && prim.type == values.resource_type {return true;}
             }
           }
-          return false;          
+          return false;
     failure_message: SAPHana resource is not correctly configured

--- a/checks/AE0C60.yaml
+++ b/checks/AE0C60.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C60"
 name: SAPHana resource has monitor interval correctly configured for master role
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   SAPHana resource has monitor interval correctly configured for master role
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHana resource has monitor interval correctly configured for master role and the configuration is not missing. 
+  This Trento check verified if SAPHana resource has monitor interval correctly configured for master role and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.interval == values.monitor_interval {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHana resource has monitor interval not correctly configured

--- a/checks/AE0C61.yaml
+++ b/checks/AE0C61.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C61"
 name: SAPHana resource has monitor interval correctly configured for slave role
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   SAPHana resource has monitor interval correctly configured for slave role
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHana resource has monitor interval correctly configured for slave role and the configuration is not missing. 
+  This Trento check verified if SAPHana resource has monitor interval correctly configured for slave role and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.interval == values.monitor_interval {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHana resource has monitor interval not correctly configured

--- a/checks/AE0C62.yaml
+++ b/checks/AE0C62.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C62"
 name: SAPHana resource has monitor timeout correctly configured for master role
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   SAPHana resource has monitor timeout correctly configured for master role
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHana resource has monitor timeout correctly configured for master role and the configuration is not missing. 
+  This Trento check verified if SAPHana resource has monitor timeout correctly configured for master role and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.timeout == values.monitor_timeout {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHana resource has monitor timeout not correctly configured for Master role

--- a/checks/AE0C63.yaml
+++ b/checks/AE0C63.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C63"
 name: SAPHana resource has monitor timeout correctly configured for slave role
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   SAPHana resource has monitor timeout correctly configured for slave role
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHana resource has monitor timeout correctly configured for slave role and the configuration is not missing. 
+  This Trento check verified if SAPHana resource has monitor timeout correctly configured for slave role and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.timeout == values.monitor_timeout {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHana resource has monitor timeout not correctly configured

--- a/checks/AE0C64.yaml
+++ b/checks/AE0C64.yaml
@@ -1,11 +1,14 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C64"
-name: SAPHana resource has start timeout correctly configured 
+name: SAPHana resource has start timeout correctly configured
 group: Pacemaker
 description: |
-  SAPHana resource has start timeout correctly configured 
+  SAPHana resource has start timeout correctly configured
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHana resource has start timeout correctly configured and the configuration is not missing. 
+  This Trento check verified if SAPHana resource has start timeout correctly configured and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.timeout == values.start_timeout {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHana resource has start timeout not correctly configured

--- a/checks/AE0C65.yaml
+++ b/checks/AE0C65.yaml
@@ -1,11 +1,14 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C65"
-name: SAPHana resource has stop timeout correctly configured 
+name: SAPHana resource has stop timeout correctly configured
 group: Pacemaker
 description: |
-  SAPHana resource has stop timeout correctly configured 
+  SAPHana resource has stop timeout correctly configured
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHana resource has stop timeout correctly configured and the configuration is not missing. 
+  This Trento check verified if SAPHana resource has stop timeout correctly configured and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.timeout == values.stop_timeout {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHana resource has stop timeout not correctly configured

--- a/checks/AE0C67.yaml
+++ b/checks/AE0C67.yaml
@@ -1,11 +1,14 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C67"
-name: SAPHana resource has promote timeout correctly configured 
+name: SAPHana resource has promote timeout correctly configured
 group: Pacemaker
 description: |
-  SAPHana resource has promote timeout correctly configured 
+  SAPHana resource has promote timeout correctly configured
 remediation: |
   ## Abstract
-  This Trento check verified if SAPHana resource has promote timeout correctly configured and the configuration is not missing. 
+  This Trento check verified if SAPHana resource has promote timeout correctly configured and the configuration is not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_5_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -64,7 +67,7 @@ expectations:
                 if op == () {return false};
                 if op.timeout == values.promote_timeout {return true;}
               }
-             }                  
+             }
             }
-          return false;          
+          return false;
     failure_message: SAPHana resource has ptomote timeout not correctly configured

--- a/checks/AE0C68.yaml
+++ b/checks/AE0C68.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C68"
 name: default_primary_timeout
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   DUPLICATE_PRIMARY_TIMEOUT has correct value
 remediation: |
   ## Abstract
-  DUPLICATE_PRIMARY_TIMEOUT should have recommended value in cluster configuration. 
+  DUPLICATE_PRIMARY_TIMEOUT should have recommended value in cluster configuration.
 
   ## Remediation
   Edit the crm configuration and change the value for this parameter to 7200.
@@ -34,15 +37,15 @@ remediation: |
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
-  architecture_type: 
+  architecture_type:
     - angi
     - classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized    
+    - cost_optimized
 
 facts:
   - name: resources
@@ -51,7 +54,7 @@ facts:
 
 values:
   - name: expected_default_primary_timeout
-    default: 7200      
+    default: 7200
 
 expectations:
   - name: expectations_default_primary
@@ -81,4 +84,4 @@ expectations:
           }
         }
         return false;
-    failure_message: The value of DUPLICATE_PRIMARY_TIMEOUT configured is non-standard/non-default. 
+    failure_message: The value of DUPLICATE_PRIMARY_TIMEOUT configured is non-standard/non-default.

--- a/checks/AE0C69.yaml
+++ b/checks/AE0C69.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C69"
 name: prefer_site_takeover
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   PREFER_SITE_TAKEOVER has correct value
 remediation: |
   ## Abstract
-  PREFER_SITE_TAKEOVER should have recommended value in cluster configuration. 
+  PREFER_SITE_TAKEOVER should have recommended value in cluster configuration.
 
   ## Remediation
   Edit the crm configuration and change the value for this parameter to as per best practices recommendation.
@@ -34,15 +37,15 @@ remediation: |
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
-  architecture_type: 
+  architecture_type:
     - angi
     - classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized    
+    - cost_optimized
 
 facts:
   - name: resources
@@ -56,7 +59,7 @@ values:
       - value: true
         when: env.hana_scenario == "performance_optimized"
       - value: false
-        when: env.hana_scenario == "cost_optimized"    
+        when: env.hana_scenario == "cost_optimized"
 
 expectations:
   - name: expectations_prefer_site_takeover
@@ -86,4 +89,4 @@ expectations:
           }
         }
         return false;
-    failure_message: The value of PREFER_SITE_TAKEOVER configured is non-standard/non-default. 
+    failure_message: The value of PREFER_SITE_TAKEOVER configured is non-standard/non-default.

--- a/checks/AE0C6A.yaml
+++ b/checks/AE0C6A.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C6A"
 name: SAPHana multi-state resource has clone-node-max correctly configured
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   SAPHana multi-state resource has clone-node-max correctly configured
 remediation: |
   ## Abstract
-  SAPHana multi-state resource has clone-node-max correctly configured and not missing. 
+  SAPHana multi-state resource has clone-node-max correctly configured and not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_6_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -62,5 +65,5 @@ expectations:
                 if cnx.value == values.clone_node_max {return true};
               }
             }
-          return false;          
+          return false;
     failure_message: SAPHana multi-state resource has clone-node-max not correctly configured

--- a/checks/AE0C6B.yaml
+++ b/checks/AE0C6B.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C6B"
 name: SAPHana multi-state resource has interleave correctly configured
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   SAPHana multi-state resource has interleave correctly configured
 remediation: |
   ## Abstract
-  SAPHana multi-state resource has interleave correctly configured and not missing. 
+  SAPHana multi-state resource has interleave correctly configured and not missing.
 
   ## Remediation
 
@@ -15,32 +18,32 @@ remediation: |
   Azure:
 
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_6_saphanasr
-    
+
   AWS:
 
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
   architecture_type: classic
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -62,5 +65,5 @@ expectations:
                 if cnx.value == values.interleave {return true};
               }
             }
-          return false;          
+          return false;
     failure_message: SAPHana multi-state resource has interleave not correctly configured

--- a/checks/AE0C6C.yaml
+++ b/checks/AE0C6C.yaml
@@ -1,11 +1,14 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AE0C6C"
 name: SAPHana resource has meta attribute priority correctly configured
 group: Pacemaker
 description: |
-  SAPHana resource has meta attribute priority correctly configured 
+  SAPHana resource has meta attribute priority correctly configured
 remediation: |
   ## Abstract
-  This Trento check verifies if SAPHana resource SAPHana resource has meta attribute priority correctly configured and not missing for 2 node cluster. 
+  This Trento check verifies if SAPHana resource SAPHana resource has meta attribute priority correctly configured and not missing for 2 node cluster.
 
   ## Remediation
   Edit the crm configuration and make changes as per the best practice guide
@@ -13,30 +16,30 @@ remediation: |
   ## References
   Azure:
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr#tabpanel_6_saphanasr
-    
+
   AWS:
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
-  
+
   GCP:
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
-    
-  SUSE / KVM:       
+
+  SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
-                  
-  Nutanix:            
+
+  Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
-  architecture_type: 
+  architecture_type:
     - classic
     - angi
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -49,7 +52,7 @@ facts:
 
   - name: cib_num_nodes
     gatherer: cibadmin@v1
-    argument: cib.configuration.nodes.node    
+    argument: cib.configuration.nodes.node
 
 values:
   - name: meta_priority
@@ -78,20 +81,20 @@ expectations:
             return false;
           }
 
-          if facts.corosync_num_nodes.len == 2 { 
+          if facts.corosync_num_nodes.len == 2 {
           for cln in masters_and_clones {
             let msl = cln.primitive;
             for prim in msl {
-              if prim.type == "SAPHana" || prim.type == "SAPHanaController" {              
+              if prim.type == "SAPHana" || prim.type == "SAPHanaController" {
                 let meta_attr = prim.meta_attributes;
                 for meta in meta_attr {
-                  if meta.nvpair.find(|item| item.name == "priority").value == values.meta_priority { return true; }              
+                  if meta.nvpair.find(|item| item.name == "priority").value == values.meta_priority { return true; }
                 }
-            }  
+            }
             }
           }
           return false;
           } else {
             false
-          }             
+          }
     failure_message: SAPHana/SAPHanaController resource has meta attribute priority not correctly configured

--- a/checks/AF7D5C.yaml
+++ b/checks/AF7D5C.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AF7D5C"
 name: Clustered SAP instances in Instance List
 group: Sapcontrol
@@ -28,9 +31,9 @@ expectations:
         if !facts.system_instance_list.contains(sid) { return false; }
         for cl_inst in facts.cluster_sids[sid].instances {
           if cl_inst.local && facts.system_instance_list[sid].find(|sap_inst| sap_inst.name == cl_inst.name) == () {
-            return false;  
+            return false;
           }
         }
       }
-      return true;      
+      return true;
     failure_message: Sapcontrol GetSystemInstanceList does not include all clustered SAP instances

--- a/checks/AFDA1E.yaml
+++ b/checks/AFDA1E.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "AFDA1E"
 name: ASCS instance failure-timeout and migration-threshold - ENSA2
 group: ASCS / ERS Cluster - cluster resources
@@ -43,7 +46,7 @@ facts:
 values:
   - name: resource_type
     default: ASCS
-expectations:  
+expectations:
   - name: resource_failure_timeout
     expect: |
       let sids = facts.cluster_sids.keys();

--- a/checks/B089BE.yaml
+++ b/checks/B089BE.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "B089BE"
 name: SBD watchdog timeout
 group: SBD
@@ -33,12 +36,12 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/B3BD54.yaml
+++ b/checks/B3BD54.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "B3BD54"
 name: ASCS and ERS instance directory ownership
 group: Filesystems

--- a/checks/B3DA7E.yaml
+++ b/checks/B3DA7E.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "B3DA7E"
 name: Cluster resource-stickiness and migration-threshold
 group: Pacemaker
@@ -49,7 +52,7 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - ascs_ers
   hana_scenario: performance_optimized

--- a/checks/BA215C.yaml
+++ b/checks/BA215C.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "BA215C"
 name: corosync.conf files are identical
 group: Corosync
@@ -18,11 +21,11 @@ remediation: |
 
   GCP:
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
-  
+
   Nutanix:
 
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-example-for-etccorosynccorosync-conf
-  
+
   SUSE / KVM:
 
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-example-for-etccorosynccorosync-conf
@@ -34,11 +37,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/BB6874.yaml.wip
+++ b/checks/BB6874.yaml.wip
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "BB6874"
 name: Tune tcp_retries2
 group: OS settings

--- a/checks/BC9DF9.yaml
+++ b/checks/BC9DF9.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "BC9DF9"
 name: Python3 version identical on all nodes
 group: OS and package versions
@@ -16,11 +19,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/BE3C0E.yaml
+++ b/checks/BE3C0E.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "BE3C0E"
 name: sapsys and sapinst groups exist
 group: OS users/groups

--- a/checks/C15B2C.yaml
+++ b/checks/C15B2C.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "C15B2C"
 name: ASCS instance priority
 group: ASCS / ERS Cluster - cluster resources
@@ -67,7 +70,7 @@ values:
     default: ASCS
   - name: resource_priority
     default: 10
-expectations:  
+expectations:
   - name: resource_priority
     expect: |
       if facts.cib_configuration.nodes.node.len != 2 { return true; } // only run on 2 node cluster
@@ -79,10 +82,10 @@ expectations:
         if group == () { return false; }
         let prim = group.primitive.find(|p| p.type == "SAPInstance" && p.contains("meta_attributes"));
         if prim == () { return false; }
-        
+
         let result = prim.meta_attributes[0].nvpair
           .find(|nv| nv.name == "priority" && nv.value == values.resource_priority);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} resource does not have correct priority ${values.resource_priority_ascs}

--- a/checks/C3166E.yaml
+++ b/checks/C3166E.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "C3166E"
 name: unsupported sbd version
 group: OS and package versions
@@ -12,12 +15,12 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
   provider: [azure, nutanix, kvm, vmware]
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/C620DC.yaml
+++ b/checks/C620DC.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "C620DC"
 name: Check Corosync expected_votes value
 group: Corosync
@@ -47,10 +50,10 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:
@@ -64,7 +67,7 @@ facts:
 
   - name: cib_num_nodes
     gatherer: cibadmin@v1
-    argument: cib.configuration.nodes.node    
+    argument: cib.configuration.nodes.node
 
 expectations:
   - name: num_nodes_equal_in_corosync_and_cib

--- a/checks/C74B02.yaml
+++ b/checks/C74B02.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "C74B02"
 name: supported resource-agents version
 group: OS and package versions
@@ -16,7 +19,7 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: ascs_ers 
+  cluster_type: ascs_ers
 
 facts:
   - name: compare_resource_agents

--- a/checks/C835E0.yaml
+++ b/checks/C835E0.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "C835E0"
 name: ERS Enqueue replication server restart is disabled - ENSA1
 group: SAP profiles
@@ -49,8 +52,8 @@ expectations:
         let inst = facts.cluster_sids[sid].instances.find(|inst| inst.name == `ERS${inst.instance_number}`);
         if inst == () { return false; }
         let result = facts.sap_profiles[sid].profiles.find(|p| {
-          p.content.contains("INSTANCE_NAME") && 
-          p.content["INSTANCE_NAME"] == inst.name && 
+          p.content.contains("INSTANCE_NAME") &&
+          p.content["INSTANCE_NAME"] == inst.name &&
           !p.content.contains("Restart_Program_00") && // check restart is disabled
           p.content.contains("Start_Program_00")       // check start is enabled
         });

--- a/checks/CAEFF1.yaml
+++ b/checks/CAEFF1.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "CAEFF1"
 name: OS flavor SLES_SAP
 group: OS and package versions
@@ -38,11 +41,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/CCEF3B.yaml
+++ b/checks/CCEF3B.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "CCEF3B"
 name: ASCS group order - resource_managed
 group: ASCS / ERS Cluster - cluster resources
@@ -69,7 +72,7 @@ values:
           - anything
           - IPaddr2
           - SAPInstance
-expectations:  
+expectations:
   - name: check_group_order
     expect: |
       for sid in facts.cluster_sids.keys() {
@@ -81,5 +84,5 @@ expectations:
           let found_types = group.primitive.map(|p| p.type);
           if found_types != values.resource_order { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} group has wrong resource order, correct order would be ${values.resource_order}

--- a/checks/D028B9.yaml
+++ b/checks/D028B9.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "D028B9"
 name: OS version SLES_SAP
 group: OS and package versions
@@ -15,11 +18,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/D78671.yaml
+++ b/checks/D78671.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "D78671"
 name: Check Corosync two_node value during runtime
 group: Corosync
@@ -49,10 +52,10 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:
@@ -66,7 +69,7 @@ facts:
 
   - name: cib_num_nodes
     gatherer: cibadmin@v1
-    argument: cib.configuration.nodes.node      
+    argument: cib.configuration.nodes.node
 
 values:
   - name: expected_runtime_two_node
@@ -79,14 +82,14 @@ expectations:
   - name: num_nodes_equal_in_corosync_and_cib
     expect: facts.corosync_num_nodes.len == facts.cib_num_nodes.len
     failure_message: Number of nodes mentioned in corosync.conf and cib.xml are not equal
-  
+
   - name: expectations_two_node
     expect: |
-     if facts.corosync_num_nodes.len == 2 { 
-       facts.runtime_two_node == values.expected_runtime_two_node 
-     } else if facts.corosync_num_nodes.len >= 3 { 
-       facts.runtime_two_node == values.expected_runtime_threeormore 
+     if facts.corosync_num_nodes.len == 2 {
+       facts.runtime_two_node == values.expected_runtime_two_node
+     } else if facts.corosync_num_nodes.len >= 3 {
+       facts.runtime_two_node == values.expected_runtime_threeormore
      } else {
        false
      }
-    failure_message: Corosync 'two_node' value was expected to be 1 when there are 2 nodes and 0 when there 3 or more nodes but configured value is '${facts.runtime_two_node}' when there are '${facts.corosync_num_nodes.len}' number of nodes    
+    failure_message: Corosync 'two_node' value was expected to be 1 when there are 2 nodes and 0 when there 3 or more nodes but configured value is '${facts.runtime_two_node}' when there are '${facts.corosync_num_nodes.len}' number of nodes

--- a/checks/DA114A.yaml
+++ b/checks/DA114A.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "DA114A"
 name: Corosync rings
 group: Corosync
@@ -34,11 +37,11 @@ severity: warning
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/DAD58C.yaml
+++ b/checks/DAD58C.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "DAD58C"
 name: ASCS group order - simple_mount
 group: ASCS / ERS Cluster - cluster resources
@@ -69,7 +72,7 @@ values:
           - IPaddr2
           - SAPStartSrv
           - SAPInstance
-expectations:  
+expectations:
   - name: check_group_order
     expect: |
       for sid in facts.cluster_sids.keys() {
@@ -81,5 +84,5 @@ expectations:
           let found_types = group.primitive.map(|p| p.type);
           if found_types != values.resource_order { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} group has wrong resource order, correct order would be ${values.resource_order}

--- a/checks/DC5429.yaml
+++ b/checks/DC5429.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "DC5429"
 name: supported corosync version
 group: OS and package versions
@@ -18,11 +21,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/DE74B2.yaml
+++ b/checks/DE74B2.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "DE74B2"
 name: Azure Fence agent configuration
 group: Azure Fence Agent
@@ -29,12 +32,12 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
   provider: azure
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/DF8328.yaml
+++ b/checks/DF8328.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "DF8328"
 name: corosync version identical on all nodes
 group: OS and package versions
@@ -17,11 +20,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/DFDB82.yaml
+++ b/checks/DFDB82.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "DFDB82"
 name: HA interface has 2 or more nodes
 group: Sapcontrol
@@ -10,10 +13,10 @@ remediation: |
 
   ## Remediation
   Above problem could happen due to several reasons. E.g.
-  
+
     1. The <SID>adm user in not part of haclient group.
     2. The cluster use ACL to control access and haclient doesn't have the needed rights.
-    3. The ASCS/ERS resource contains wrong parameters. 
+    3. The ASCS/ERS resource contains wrong parameters.
     4. The ownership of the <SID>adm user /home/<SID>adm/.config directory is not set correctly to <SID>adm:sapsys.
     5. On SLE15 SP5 the packages crmsh and crmsh-scripts are not on the latest patch level and should have at least version crmsh-4.4.0+20221028.3e41444-150400.3.9.1
     6. /var/lib/heartbeat/cores/hacluster directory needs group read/execute permission (chmod 750 /var/lib/heartbeat/cores/hacluster)
@@ -61,10 +64,10 @@ expectations:
   - name: ha_nodes_count
     expect: |
       for sid in facts.cluster_sids.keys() {
-        if !facts.ha_get_failover_config.contains(sid) || 
+        if !facts.ha_get_failover_config.contains(sid) ||
           facts.ha_get_failover_config[sid].all(|i| i.output.ha_nodes.len < 2) {
             return false;
         }
       }
-      return true;      
+      return true;
     failure_message: Sapcontrol HAGetFailoverConfig 'ha_nodes' does not have at least 2 nodes for every instance

--- a/checks/E090D8.yaml
+++ b/checks/E090D8.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "E090D8"
 name: /usr/sap is local filesystem
 group: Filesystems
@@ -23,7 +26,7 @@ facts:
 expectations:
   - name: usr_sap_not_on_nfs
     expect: |
-      facts.fstab.find(|line| 
+      facts.fstab.find(|line|
         line.mount_point == "/usr/sap" &&
         line.file_system_type.starts_with("nfs")
       ) == ();

--- a/checks/E1F2C3.yaml
+++ b/checks/E1F2C3.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "E1F2C3"
 name: SAPHanaController roles correctly configured
 group: Pacemaker
@@ -20,7 +23,7 @@ remediation: |
   AWS:
 
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.12.3
-    - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanacontroller  
+    - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanacontroller
 
   GCP:
 
@@ -30,7 +33,7 @@ remediation: |
   SUSE / KVM:
 
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.12.3
-    - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanacontroller   
+    - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanacontroller
 
   Nutanix:
 
@@ -41,13 +44,13 @@ remediation: |
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
   architecture_type: angi
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: controller_roles
@@ -56,10 +59,10 @@ facts:
 
 values:
   - name: promoted_role
-    customization_disabled: true  
+    customization_disabled: true
     default: "Promoted"
   - name: unpromoted_role
-    customization_disabled: true  
+    customization_disabled: true
     default: "Unpromoted"
 
 expectations:
@@ -79,4 +82,4 @@ expectations:
           }
         }
         return false;
-    failure_message:  Roles configured for SAPHanaController Monitor Operations are not correct              
+    failure_message:  Roles configured for SAPHanaController Monitor Operations are not correct

--- a/checks/E215A6.yaml
+++ b/checks/E215A6.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "E215A6"
 name: SAPHanaFilesystem resource configured
 group: Pacemaker
@@ -34,13 +37,13 @@ remediation: |
 severity: warning
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
   architecture_type: angi
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resource_filesystem
@@ -50,7 +53,7 @@ facts:
 values:
   - name: resource_type
     customization_disabled: true
-    default: "SAPHanaFilesystem"      
+    default: "SAPHanaFilesystem"
 
 expectations:
   - name: expectations_resource_filesystem
@@ -59,8 +62,8 @@ expectations:
             for cln in hana_ct {
               let fil = cln.primitive;
               for prim in fil {
-                if prim.type == values.resource_type {return true;}       
+                if prim.type == values.resource_type {return true;}
               }
             }
             return false;
-    failure_message: SAPHanaFilesystem resource is not configured            
+    failure_message: SAPHanaFilesystem resource is not configured

--- a/checks/E4D1B4.yaml
+++ b/checks/E4D1B4.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "E4D1B4"
 name: SAPHanaTopology monitor interval has correct value
 group: Pacemaker
@@ -5,7 +8,7 @@ description: |
   SAPHanaTopology monitor interval has correct value
 remediation: |
   ## Abstract
-  SAPHanaTopology monitor interval should have recommended value in cluster configuration. 
+  SAPHanaTopology monitor interval should have recommended value in cluster configuration.
 
   ## Remediation
 
@@ -30,23 +33,23 @@ remediation: |
   SUSE / KVM:
 
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.10.4
-    - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanatopology    
+    - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanatopology
 
   Nutanix:
 
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.10.4
-    - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanatopology    
+    - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanatopology
 
 severity: warning
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
   architecture_type: angi
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: topology_monitor
@@ -55,7 +58,7 @@ facts:
 
 values:
   - name: topology_interval
-    default: 50      
+    default: 50
 
 expectations:
   - name: expectations_topology_monitor_interval
@@ -70,5 +73,5 @@ expectations:
               }
             }
           }
-          return false;          
-    failure_message: Interval for "Monitor" Operation for SAPHanaTopology resource is not set correctly              
+          return false;
+    failure_message: Interval for "Monitor" Operation for SAPHanaTopology resource is not set correctly

--- a/checks/EA12BC.yaml
+++ b/checks/EA12BC.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "EA12BC"
 name: SAPHanaController resource is configured
 group: Pacemaker
@@ -16,37 +19,37 @@ remediation: |
 
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.12.3
     - https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal%2Csaphanasr-angi
-    
+
   AWS:
 
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.12.3
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanacontroller
-  
+
   GCP:
 
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-scaleout-config-sles#sles-for-sap-15-sp6-or-later_5
     - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp6-or-later_3
-    
-  SUSE / KVM: 
-            
+
+  SUSE / KVM:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.12.3
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanacontroller
-                  
-  Nutanix:        
-                  
+
+  Nutanix:
+
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.12.3
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanacontroller
 
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
   architecture_type: angi
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -65,8 +68,8 @@ expectations:
           for cln in hana_ct {
             let mst = cln.primitive;
             for prim in mst {
-              if prim.type == values.resource_type {return true;}                  
+              if prim.type == values.resource_type {return true;}
             }
           }
-          return false;          
-    failure_message: SAPHanaController resource is not configured              
+          return false;
+    failure_message: SAPHanaController resource is not configured

--- a/checks/EB24D1.yaml
+++ b/checks/EB24D1.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "EB24D1"
 name: SAPHanaController is configured as Clone
 group: Pacemaker
@@ -31,7 +34,7 @@ remediation: |
 
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.12.3
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-perfopt-15/index.html#id-saphanacontroller
-                  
+
   Nutanix:
 
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-angi-scaleout-perfopt-15/index.html#id-1.11.7.1
@@ -40,13 +43,13 @@ remediation: |
 severity: critical
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
   architecture_type: angi
   hana_scenario:
     - performance_optimized
-    - cost_optimized  
+    - cost_optimized
 
 facts:
   - name: resources
@@ -71,5 +74,5 @@ expectations:
                 }
               }
             }
-            return false;            
-    failure_message: The multi-state resource is either not configured as "clone" or the meta attribute "promotable" is not set to "true"            
+            return false;
+    failure_message: The multi-state resource is either not configured as "clone" or the meta attribute "promotable" is not set to "true"

--- a/checks/EE4EF9.yaml
+++ b/checks/EE4EF9.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "EE4EF9"
 name: ASCS Message server restart is enabled
 group: SAP profiles
@@ -45,12 +48,12 @@ expectations:
         let inst = facts.cluster_sids[sid].instances.find(|inst| inst.name == `ASCS${inst.instance_number}`);
         if inst == () { return false; }
         let result = facts.sap_profiles[sid].profiles.find(|p| {
-          p.content.contains("INSTANCE_NAME") && 
-          p.content["INSTANCE_NAME"] == inst.name && 
+          p.content.contains("INSTANCE_NAME") &&
+          p.content["INSTANCE_NAME"] == inst.name &&
           !p.content.contains("Start_Program_00") && // check start is disabled
           p.content.contains("Restart_Program_00")   // check restart is enabled
         });
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one the message server restart is disabled and has to be enabled.

--- a/checks/F0337F.yaml
+++ b/checks/F0337F.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "F0337F"
 name: ASCS and ERS location - ENSA2
 group: ASCS / ERS Cluster - cluster resources
@@ -41,7 +44,7 @@ facts:
   - name: cib_configuration
     gatherer: cibadmin@v1
     argument: cib.configuration
-expectations:  
+expectations:
   - name: location_ascs_ers_absent
     expect: |
       let sids = facts.cluster_sids.keys();
@@ -56,5 +59,5 @@ expectations:
             l.rule.expression.attribute == "runs_ers_" + sid);
         if result != () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one location constraint was found for this ENSA2 ASCS/ERS setup but there should not be any

--- a/checks/F306C2.yaml
+++ b/checks/F306C2.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "F306C2"
 name: ERS instance priority
 group: ASCS / ERS Cluster - cluster resources
@@ -67,7 +70,7 @@ values:
     default: ERS
   - name: resource_priority
     default: 1000
-expectations:  
+expectations:
   - name: resource_priority
     expect: |
       if facts.cib_configuration.nodes.node.len != 2 { return true; } // only run on 2 node cluster
@@ -79,10 +82,10 @@ expectations:
         if group == () { return false; }
         let prim = group.primitive.find(|p| p.type == "SAPInstance" && p.contains("meta_attributes"));
         if prim == () { return false; }
-        
+
         let result = prim.meta_attributes[0].nvpair
           .find(|nv| nv.name == "priority" && nv.value == values.resource_priority);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} resource does not have correct priority ${values.resource_priority_ascs}

--- a/checks/F50AF5.yaml
+++ b/checks/F50AF5.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "F50AF5"
 name: supported python3 version
 group: OS and package versions
@@ -15,11 +18,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/F55857.yaml
+++ b/checks/F55857.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "F55857"
 name: ERS Enqueue replication server restart is disabled - ENSA2
 group: SAP profiles
@@ -49,8 +52,8 @@ expectations:
         let inst = facts.cluster_sids[sid].instances.find(|inst| inst.name == `ERS${inst.instance_number}`);
         if inst == () { return false; }
         let result = facts.sap_profiles[sid].profiles.find(|p| {
-          p.content.contains("INSTANCE_NAME") && 
-          p.content["INSTANCE_NAME"] == inst.name && 
+          p.content.contains("INSTANCE_NAME") &&
+          p.content["INSTANCE_NAME"] == inst.name &&
           !p.content.contains("Restart_Program_00") && // check restart is disabled
           p.content.contains("Start_Program_00")       // check start is enabled
         });

--- a/checks/F6CFDB.yaml
+++ b/checks/F6CFDB.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "F6CFDB"
 name: ASCS Enqueue server restart is disabled - ENSA1
 group: SAP profiles
@@ -49,12 +52,12 @@ expectations:
         let inst = facts.cluster_sids[sid].instances.find(|inst| inst.name == `ASCS${inst.instance_number}`);
         if inst == () { return false; }
         let result = facts.sap_profiles[sid].profiles.find(|p| {
-          p.content.contains("INSTANCE_NAME") && 
+          p.content.contains("INSTANCE_NAME") &&
           p.content["INSTANCE_NAME"] == inst.name &&
           !p.content.contains("Restart_Program_01") && // check restart is disabled
           p.content.contains("Start_Program_01")       // check start is enabled
         });
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one enqueue server restart is enabled and has to be disabled.

--- a/checks/F98557.yaml
+++ b/checks/F98557.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "F98557"
 name: ASCS instance failure-timeout and migration-threshold - ENSA1
 group: ASCS / ERS Cluster - cluster resources
@@ -54,7 +57,7 @@ values:
     default: 1
   - name: resource_type
     default: ASCS
-expectations:  
+expectations:
   - name: resource_failure_timeout
     expect: |
       let sids = facts.cluster_sids.keys();
@@ -70,7 +73,7 @@ expectations:
           .find(|nv| nv.name == "failure-timeout" && nv.value == values.resource_failure_timeout);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} resource does not have correct failure-timeout of ${values.resource_failure_timeout}
   - name: resource_migration_threshold
     expect: |
@@ -87,5 +90,5 @@ expectations:
           .find(|nv| nv.name == "migration-threshold" && nv.value == values.resource_migration_threshold);
         if result == () { return false; }
       }
-      return true;      
+      return true;
     failure_message: At least one ${values.resource_type} resource does not have correct migration-threshold of ${values.resource_migration_threshold}

--- a/checks/FA37C7.yaml
+++ b/checks/FA37C7.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "FA37C7"
 name: no ban and move locations
 group: Pacemaker
@@ -13,7 +16,7 @@ remediation: |
   Remove these constraints by editing the CIB or using `crm resource clear $resource`
 
   ## References
-  
+
     - https://www.suse.com/c/sles-for-sap-hana-maintenance-procedures-part-2-manual-administrative-tasks-os-reboots-and-updation-of-os-and-hana/
 
 
@@ -26,7 +29,7 @@ facts:
     gatherer: cibadmin@v1
     argument: cib.configuration
 
-expectations:  
+expectations:
   - name: no_ban_constraints
     expect: |
       if !facts.cib_configuration.contains("constraints") { return true; } // constraints do not exist

--- a/checks/FB0E0D.yaml
+++ b/checks/FB0E0D.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "FB0E0D"
 name: Check Corosync consensus timeout during runtime
 group: Corosync
@@ -48,11 +51,11 @@ remediation: |
 
 metadata:
   target_type: cluster
-  cluster_type: 
+  cluster_type:
     - hana_scale_up
     - hana_scale_out
     - ascs_ers
-  hana_scenario: 
+  hana_scenario:
     - performance_optimized
     - cost_optimized
 facts:

--- a/checks/FB95CD.yaml
+++ b/checks/FB95CD.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 id: "FB95CD"
 name: sapinit generated and started
 group: Saphostagent

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 version: "3.7"
 
 services:
@@ -42,4 +45,3 @@ services:
 
 volumes:
   pg_data:
-

--- a/hack/get_version_from_git.sh
+++ b/hack/get_version_from_git.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 set -e
 set -o pipefail
 

--- a/hack/gh_release_to_obs_changeset.py
+++ b/hack/gh_release_to_obs_changeset.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
 import argparse
 import json
 import os

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: GPL-3.0-or-later
 #!BuildTag: trento/trento-checks:latest
 #!BuildTag: trento/trento-checks:%%VERSION%%

--- a/packaging/suse/rpm/trento-checks.spec
+++ b/packaging/suse/rpm/trento-checks.spec
@@ -1,7 +1,8 @@
 #
 # spec file for package trento-checks
 #
-# Copyright (c) 2024 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Besides, a new linter is added for the CI to check the license headers. 

Related # TRNT-4358

## How was this tested?

License linter.