### PR TITLE
Adding second name to the GHCR image, trento-checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,9 +48,12 @@ jobs:
       - tlint
     if: >-
       github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    strategy:
+      matrix:
+        imgname: ["checks", "trento-checks"]
     uses: trento-project/.github/.github/workflows/publish-containers.yaml@406be0972195864a87ed454458eaa0856d0c5457 # v1.6.0
     with:
-      image_name: checks
+      image_name: ${{ matrix.imgname }}
       tag: rolling
     secrets:
       gh_token: ${{ secrets.TRENTOBOT_GH_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
       - release
     strategy:
       matrix:
+        imgname: ["checks", "trento-checks"]
         include:
           - tag: ${{ needs.release.outputs.version }}
             branch: ${{ github.ref_name }}
@@ -36,7 +37,7 @@ jobs:
     uses: trento-project/.github/.github/workflows/publish-containers.yaml@406be0972195864a87ed454458eaa0856d0c5457 # v1.6.0
     with:
       branch: ${{ matrix.branch }}
-      image_name: checks
+      image_name: ${{ matrix.imgname }}
       tag: ${{ matrix.tag }}
     secrets:
       gh_token: ${{ secrets.TRENTOBOT_GH_PAT }}

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -15,4 +15,5 @@ header:
     - "**/*.md"
     - ".github/dependabot.yml"
     - "LICENSE"
+    - "VERSION"
     - "packaging/suse/rpm/trento-checks.spec"


### PR DESCRIPTION
Adding second name to the image that is published on GHCR -- `trento-check`. This simplifies the helm-chart configuration and unifies the naming of our images.