### PR TITLE
fix of metadata hana-scale_out to hana_scale_out

### DIFF
--- a/checks/3D8599.yaml
+++ b/checks/3D8599.yaml
@@ -34,7 +34,7 @@ metadata:
   target_type: cluster
   cluster_type:
     - hana_scale_up
-    - hana-scale_out
+    - hana_scale_out
   architecture_type:
     - classic
     - angi


### PR DESCRIPTION
### Description

metadata cluster_type had one value "hana_scale_out" incorrect. This PR fixes it
