### PR TITLE
Addition of majority maker exclude predictate to relevant checks

### DIFF
--- a/checks/3A59DC.yaml
+++ b/checks/3A59DC.yaml
@@ -3,6 +3,8 @@
 
 id: "3A59DC"
 name: The recommended Solution is enabled
+exclude: |
+  host.is_majority_maker == true
 group: saptune
 description: |
   Check if the recommended Solution is enabled on the system. The recommendation is based on the SAP product detection of Trento.
@@ -11,7 +13,7 @@ remediation: |
   ## Abstract
   The enabled Solution is **not** the recommended one.
 
-  Note: This check cannot be used on clusters with majority maker.
+  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
 
   ## Remediation
   Enable the recommended Solution with `saptune solution change <SOLUTION>`.

--- a/checks/3A59DC.yaml
+++ b/checks/3A59DC.yaml
@@ -3,8 +3,6 @@
 
 id: "3A59DC"
 name: The recommended Solution is enabled
-exclude: |
-  host.is_majority_maker == true
 group: saptune
 description: |
   Check if the recommended Solution is enabled on the system. The recommendation is based on the SAP product detection of Trento.
@@ -13,7 +11,7 @@ remediation: |
   ## Abstract
   The enabled Solution is **not** the recommended one.
 
-  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
+  Note: This check cannot be used on clusters with majority maker.
 
   ## Remediation
   Enable the recommended Solution with `saptune solution change <SOLUTION>`.

--- a/checks/3A9890.yaml
+++ b/checks/3A9890.yaml
@@ -3,8 +3,6 @@
 
 id: "3A9890"
 name: saptune overrides are identical on all nodes
-exclude: |
-  host.is_majority_maker == true
 group: saptune
 description: |
   If overrides exist, we assume that these overrides are identical on all nodes.
@@ -14,7 +12,7 @@ remediation: |
   The override values must be identical on all nodes but they are different currently.
   This means some/all parameter values from the existing override files differ or an override file is missing on at least one node in the cluster.
 
-  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
+  Note: This check cannot be used on clusters with majority maker.
 
   ## Remediation
   Run `saptune note verify` on all nodes and compare the overrides.

--- a/checks/3A9890.yaml
+++ b/checks/3A9890.yaml
@@ -3,6 +3,8 @@
 
 id: "3A9890"
 name: saptune overrides are identical on all nodes
+exclude: |
+  host.is_majority_maker == true
 group: saptune
 description: |
   If overrides exist, we assume that these overrides are identical on all nodes.
@@ -12,7 +14,7 @@ remediation: |
   The override values must be identical on all nodes but they are different currently.
   This means some/all parameter values from the existing override files differ or an override file is missing on at least one node in the cluster.
 
-  Note: This check cannot be used on clusters with majority maker.
+  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
 
   ## Remediation
   Run `saptune note verify` on all nodes and compare the overrides.

--- a/checks/3AA381.yaml
+++ b/checks/3AA381.yaml
@@ -3,6 +3,8 @@
 
 id: "3AA381"
 name: The saptune package version is identical on all nodes
+exclude: |
+  host.is_majority_maker == true
 group: saptune
 description: |
   Installed saptune package version is identical on all nodes
@@ -12,7 +14,7 @@ remediation: |
   But the version of the installed saptune package differs on the cluster nodes.
   Also make sure that "SAPTUNE_VERSION" in /etc/sysconfig/saptune has identical values on all nodes.
 
-  Note: This check cannot be used on clusters with majority maker.
+  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
 
   ## Remediation
   Update the saptune package to get the same version on all cluster nodes

--- a/checks/3AA381.yaml
+++ b/checks/3AA381.yaml
@@ -3,8 +3,6 @@
 
 id: "3AA381"
 name: The saptune package version is identical on all nodes
-exclude: |
-  host.is_majority_maker == true
 group: saptune
 description: |
   Installed saptune package version is identical on all nodes
@@ -14,7 +12,7 @@ remediation: |
   But the version of the installed saptune package differs on the cluster nodes.
   Also make sure that "SAPTUNE_VERSION" in /etc/sysconfig/saptune has identical values on all nodes.
 
-  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
+  Note: This check cannot be used on clusters with majority maker.
 
   ## Remediation
   Update the saptune package to get the same version on all cluster nodes

--- a/checks/3AD734.yaml
+++ b/checks/3AD734.yaml
@@ -3,6 +3,8 @@
 
 id: "3AD734"
 name: All nodes have the same Solution and Notes enabled
+exclude: |
+  host.is_majority_maker == true
 group: saptune
 description: |
   The enabled and applied Solution and Notes are the same on all nodes
@@ -11,7 +13,7 @@ remediation: |
   ## Abstract
   The same Solution and Notes must be enabled and applied on all cluster nodes. This is the base of having the same configuration even though it does not guarantee identical tuning (e.g. staging is used or active diverging overrides)!
 
-  Note: This check cannot be used on clusters with majority maker.
+  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
 
   ## Remediation
   Enable and apply the same Solution and/or Notes on all nodes with the appropriate saptune commands.

--- a/checks/3AD734.yaml
+++ b/checks/3AD734.yaml
@@ -3,8 +3,6 @@
 
 id: "3AD734"
 name: All nodes have the same Solution and Notes enabled
-exclude: |
-  host.is_majority_maker == true
 group: saptune
 description: |
   The enabled and applied Solution and Notes are the same on all nodes
@@ -13,7 +11,7 @@ remediation: |
   ## Abstract
   The same Solution and Notes must be enabled and applied on all cluster nodes. This is the base of having the same configuration even though it does not guarantee identical tuning (e.g. staging is used or active diverging overrides)!
 
-  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
+  Note: This check cannot be used on clusters with majority maker.
 
   ## Remediation
   Enable and apply the same Solution and/or Notes on all nodes with the appropriate saptune commands.

--- a/checks/ABA3CA.yaml
+++ b/checks/ABA3CA.yaml
@@ -3,8 +3,6 @@
 
 id: "ABA3CA"
 name: SAP Host Agent is running
-exclude: |
-  host.is_majority_maker == true
 group: OS and package versions
 description: |
   SAP Host Agent is running
@@ -12,7 +10,7 @@ remediation: |
   ## Abstract
   SAP Host Agent should be running on all cluster nodes
 
-  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
+  Note: This check cannot be used on clusters with majority maker.
 
   ## Remediation
   Install and start SAP Host Agent on all nodes.

--- a/checks/ABA3CA.yaml
+++ b/checks/ABA3CA.yaml
@@ -3,6 +3,8 @@
 
 id: "ABA3CA"
 name: SAP Host Agent is running
+exclude: |
+  host.is_majority_maker == true
 group: OS and package versions
 description: |
   SAP Host Agent is running
@@ -10,7 +12,7 @@ remediation: |
   ## Abstract
   SAP Host Agent should be running on all cluster nodes
 
-  Note: This check cannot be used on clusters with majority maker.
+  Note: Majority maker nodes are excluded from execution when they exist in the cluster.
 
   ## Remediation
   Install and start SAP Host Agent on all nodes.


### PR DESCRIPTION
### Description

Checks 3A59DC, 3A9890, 3AA381, 3AD734 and ABA3CA:

- Addition of majority maker exclude predicate
- Update to note warning that the check cannot be used in clusters using majority maker

### How was this tested?

Locally in real hana scale out cluster.

### Documentation changes

No

### Additional information

Part of the Avoid check execution on non-relevant nodes epic implementation. 