### PR TITLE
Adapt checks to Pacemaker 3

### DIFF
--- a/checks/3D8598.yaml
+++ b/checks/3D8598.yaml
@@ -59,18 +59,6 @@ values:
     conditions:
       - value: 3000
         when: env.hana_scenario == "cost_optimized"
-  - name: col_with_rsc_role
-    customization_disabled: true
-    default: "Promoted"
-    conditions:
-      - value: "Master"
-        when: env.architecture_type == "classic"
-  - name: msclone
-    customization_disabled: true
-    default: "clone"
-    conditions:
-      - value: "master"
-        when: env.architecture_type == "classic"
   - name: ms_rsc_type
     customization_disabled: true
     default: "SAPHanaController"
@@ -81,8 +69,19 @@ values:
 expectations:
   - name: expectations_colocation_configured
     expect: |
+        let resources = facts.resources;
+        let masters = [];
+        let clones = [];
+        if "master" in resources {
+          masters = resources.master;
+        }
+        if "clone" in resources {
+          clones = resources.clone;
+        }
+        let masters_and_clones = masters + clones;
+
         let vip; let vip_prim; let vip_grp;
-        let saphanasr_id = facts.resources[values.msclone].find_map(|ms| if ms.primitive.find(|rsc| rsc.type == values.ms_rsc_type) != () { ms.id });
+        let saphanasr_id = masters_and_clones.find_map(|ms| if ms.primitive.find(|rsc| rsc.type == values.ms_rsc_type) != () { ms.id });
         if saphanasr_id == () { return false; }
         let primitives = facts.resources.primitive;
         for prim in primitives {
@@ -99,5 +98,5 @@ expectations:
             }
           }
         }
-        facts.constraints.rsc_colocation.find(|col| (col["rsc"] == vip_prim || col["rsc"] == vip_grp ) && col["rsc-role"] == values.col_rsc_role && col["score"] == values.col_rsc_score && col["with-rsc"] == saphanasr_id && col["with-rsc-role"] == values.col_with_rsc_role) != ()
+        facts.constraints.rsc_colocation.find(|col| (col["rsc"] == vip_prim || col["rsc"] == vip_grp ) && col["rsc-role"] == values.col_rsc_role && col["score"] == values.col_rsc_score && col["with-rsc"] == saphanasr_id && (col["with-rsc-role"] == "Promoted" || col["with-rsc-role"] == "Master")) != ()
     failure_message: Colocation constraint is not correctly configured

--- a/checks/AE0C5F.yaml
+++ b/checks/AE0C5F.yaml
@@ -61,7 +61,17 @@ values:
 expectations:
   - name: expectations_SAPHana_configured
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
             let msl = cln.primitive;
             for prim in msl {

--- a/checks/AE0C60.yaml
+++ b/checks/AE0C60.yaml
@@ -58,7 +58,17 @@ values:
 expectations:
   - name: expectations_monitor_interval_configured
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
             let rsc = cln.primitive;
             for prim in rsc {

--- a/checks/AE0C60.yaml
+++ b/checks/AE0C60.yaml
@@ -63,7 +63,7 @@ expectations:
             let rsc = cln.primitive;
             for prim in rsc {
               if prim.type == "SAPHana" {
-                let op = prim.operations.op.find(|oname| oname.name == "monitor" && oname.role == "Master");
+                let op = prim.operations.op.find(|oname| oname.name == "monitor" && (oname.role == "Master" || oname.role == "Promoted"));
                 if op == () {return false};
                 if op.interval == values.monitor_interval {return true;}
               }

--- a/checks/AE0C61.yaml
+++ b/checks/AE0C61.yaml
@@ -63,7 +63,7 @@ expectations:
             let rsc = cln.primitive;
             for prim in rsc {
               if prim.type == "SAPHana" {
-                let op = prim.operations.op.find(|oname| oname.name == "monitor" && oname.role == "Slave");
+                let op = prim.operations.op.find(|oname| oname.name == "monitor" && (oname.role == "Slave" || oname.role == "Unpromoted"));
                 if op == () {return false};
                 if op.interval == values.monitor_interval {return true;}
               }

--- a/checks/AE0C61.yaml
+++ b/checks/AE0C61.yaml
@@ -58,7 +58,17 @@ values:
 expectations:
   - name: expectations_monitor_interval_configured
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
             let rsc = cln.primitive;
             for prim in rsc {

--- a/checks/AE0C62.yaml
+++ b/checks/AE0C62.yaml
@@ -58,7 +58,17 @@ values:
 expectations:
   - name: expectations_monitor_timeout_configured
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
             let rsc = cln.primitive;
             for prim in rsc {

--- a/checks/AE0C62.yaml
+++ b/checks/AE0C62.yaml
@@ -63,7 +63,7 @@ expectations:
             let rsc = cln.primitive;
             for prim in rsc {
               if prim.type == "SAPHana" {
-                let op = prim.operations.op.find(|oname| oname.name == "monitor" && oname.role == "Master");
+                let op = prim.operations.op.find(|oname| oname.name == "monitor" && (oname.role == "Master" || oname.role == "Promoted"));
                 if op == () {return false};
                 if op.timeout == values.monitor_timeout {return true;}
               }

--- a/checks/AE0C63.yaml
+++ b/checks/AE0C63.yaml
@@ -58,7 +58,17 @@ values:
 expectations:
   - name: expectations_monitor_timeout_configured
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
             let rsc = cln.primitive;
             for prim in rsc {

--- a/checks/AE0C63.yaml
+++ b/checks/AE0C63.yaml
@@ -63,7 +63,7 @@ expectations:
             let rsc = cln.primitive;
             for prim in rsc {
               if prim.type == "SAPHana" {
-                let op = prim.operations.op.find(|oname| oname.name == "monitor" && oname.role == "Slave");
+                let op = prim.operations.op.find(|oname| oname.name == "monitor" && (oname.role == "Slave" || oname.role == "Unpromoted"));
                 if op == () {return false};
                 if op.timeout == values.monitor_timeout {return true;}
               }

--- a/checks/AE0C64.yaml
+++ b/checks/AE0C64.yaml
@@ -58,7 +58,17 @@ values:
 expectations:
   - name: expectations_start_timeout_configured
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
             let rsc = cln.primitive;
             for prim in rsc {

--- a/checks/AE0C65.yaml
+++ b/checks/AE0C65.yaml
@@ -58,7 +58,17 @@ values:
 expectations:
   - name: expectations_stop_timeout_configured
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
             let rsc = cln.primitive;
             for prim in rsc {

--- a/checks/AE0C67.yaml
+++ b/checks/AE0C67.yaml
@@ -58,7 +58,17 @@ values:
 expectations:
   - name: expectations_promote_timeout_configured
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
             let rsc = cln.primitive;
             for prim in rsc {

--- a/checks/AE0C6A.yaml
+++ b/checks/AE0C6A.yaml
@@ -58,7 +58,17 @@ values:
 expectations:
   - name: expectations_clone_node_max
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
               for ma in cln.meta_attributes {
                 let cnx = ma.nvpair.find(|item| item.name == "clone-node-max");

--- a/checks/AE0C6B.yaml
+++ b/checks/AE0C6B.yaml
@@ -58,7 +58,17 @@ values:
 expectations:
   - name: expectations_interleave
     expect: |
-          let hana_ct = facts.resources.master;
+          let masters = [];
+          let promotable_clones = [];
+          let resources = facts.resources;
+          if "master" in resources {
+            masters = resources.master;
+          }
+          if "clone" in resources {
+            promotable_clones = resources.clone.filter(|cln| cln.meta_attributes.find(|ma| ma.nvpair.find(|item| item.name == "promotable" && item.value == "true") != ()) != ());
+          }
+
+          let hana_ct = masters + promotable_clones;
           for cln in hana_ct {
               for ma in cln.meta_attributes {
                 let cnx = ma.nvpair.find(|item| item.name == "interleave");


### PR DESCRIPTION
### Description

This pull request refactors several check files to enhance compatibility and robustness for old and new Pacemaker versions.

* Support change from `<master>` to `<clone promotable=true>` syntax, that is, wherever we used `.master`, now we filter by promotable clones instead.
* Accept legacy (`master/slave`) and new roles (`promoted/unpromoted`).

Specifically:

**Refactoring for Promotable Clone Support:**

* Updated all expectation checks in files like `AE0C5F.yaml`, `AE0C60.yaml`, `AE0C61.yaml`, `AE0C62.yaml`, `AE0C63.yaml`, `AE0C64.yaml`, `AE0C65.yaml`, `AE0C67.yaml`, `AE0C6A.yaml`, and `AE0C6B.yaml` to aggregate both `master` resources and `clone` resources flagged as promotable, ensuring checks apply to all relevant resource types.

**Role Name Compatibility:**

* Modified logic to accept both `"Master"` and `"Promoted"` (and `"Slave"` and `"Unpromoted"`) as valid operation roles when searching for monitor operations, improving compatibility with different resource configurations. [

**Colocation Constraint Handling:**

* Removed unused value definitions for `col_with_rsc_role` and `msclone` in `3D8598.yaml`, and updated colocation constraint checks to accept either `"Promoted"` or `"Master"` as the `with-rsc-role`, making the check less brittle. 

Related #[TRNT-4562](https://jira.suse.com/browse/TRNT-4562)

### How was this tested?

N/A

### Documentation changes

No

### Additional information

Related to https://github.com/trento-project/checks/pull/77