### PR TITLE
Update documentation links in checks: GCP

### DIFF
--- a/checks/00081D.yaml
+++ b/checks/00081D.yaml
@@ -35,7 +35,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   SUSE / KVM:
 

--- a/checks/0AA227.yaml
+++ b/checks/0AA227.yaml
@@ -28,7 +28,7 @@ remediation: |
 
   GCP:
     - https://documentation.suse.com/sle-ha/15-SP5/single-html/SLE-HA-administration/index.html#pro-ha-storage-protect-fencing
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#set_up_fencing
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#set_up_fencing
 
   Nutanix:
     - https://documentation.suse.com/sle-ha/15-SP5/single-html/SLE-HA-administration/index.html#pro-ha-storage-protect-fencing

--- a/checks/0B0F87.yaml
+++ b/checks/0B0F87.yaml
@@ -22,6 +22,8 @@ remediation: |
 
   GCP:
 
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
+
   Nutanix:
 
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#cha.s4s.hana-hook

--- a/checks/156F64.yaml
+++ b/checks/156F64.yaml
@@ -36,7 +36,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   AWS:
 

--- a/checks/15F7A8.yaml
+++ b/checks/15F7A8.yaml
@@ -35,7 +35,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   SUSE / KVM:
 

--- a/checks/1E91FF.yaml
+++ b/checks/1E91FF.yaml
@@ -32,7 +32,7 @@ remediation: |
 
   GCP:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ascs-instance
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ascs-instance

--- a/checks/205AF7.yaml
+++ b/checks/205AF7.yaml
@@ -28,7 +28,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#configure_the_general_cluster_properties
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#configure_the_general_cluster_properties
 
   Nutanix:
 

--- a/checks/21FCA6.yaml
+++ b/checks/21FCA6.yaml
@@ -36,7 +36,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   AWS:
 

--- a/checks/24ABCB.yaml
+++ b/checks/24ABCB.yaml
@@ -35,7 +35,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   AWS:
 

--- a/checks/2A4BEE.yaml
+++ b/checks/2A4BEE.yaml
@@ -21,7 +21,7 @@ remediation: |
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-implementing-python-hook-saphanasr-in-sles.html
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
 
   SUSE / KVM:
 

--- a/checks/2A4BEF.yaml
+++ b/checks/2A4BEF.yaml
@@ -23,7 +23,7 @@ remediation: |
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-implementing-python-hook-saphanasr-in-sles.html
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
 
   SUSE / KVM:
 

--- a/checks/2A4BF0.yaml
+++ b/checks/2A4BF0.yaml
@@ -21,7 +21,7 @@ remediation: |
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-implementing-python-hook-saphanasr-in-sles.html
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#enable-hana-hadr-provider-hook
 
   SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-1.10.11.4

--- a/checks/32CFC6.yaml
+++ b/checks/32CFC6.yaml
@@ -21,7 +21,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   Nutanix:
 

--- a/checks/33403D.yaml
+++ b/checks/33403D.yaml
@@ -54,7 +54,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   AWS:
 

--- a/checks/373DB8.yaml
+++ b/checks/373DB8.yaml
@@ -31,7 +31,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#configure_the_general_cluster_properties
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#configure_the_general_cluster_properties
 
   Nutanix:
 

--- a/checks/3D8598.yaml
+++ b/checks/3D8598.yaml
@@ -22,7 +22,7 @@ remediation: |
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-constraints.html
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-constraints-for-saphanasr

--- a/checks/3D8599.yaml
+++ b/checks/3D8599.yaml
@@ -21,7 +21,7 @@ remediation: |
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-constraints.html
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-constraints-for-saphanasr

--- a/checks/3EB4C0.yaml
+++ b/checks/3EB4C0.yaml
@@ -36,7 +36,7 @@ remediation: |
 
   GCP:
     - https://documentation.suse.com/en-us/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ascs-instance
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
 
   Nutanix:
     - https://documentation.suse.com/en-us/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ascs-instance

--- a/checks/438525.yaml
+++ b/checks/438525.yaml
@@ -28,6 +28,8 @@ remediation: |
 
   GCP:
 
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#define_host_names_for_the_vip_address_in_etchosts
+
   Nutanix:
 
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#cha.hana-sr.scenario

--- a/checks/481552.yaml
+++ b/checks/481552.yaml
@@ -24,7 +24,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles
 
   SUSE / KVM:
 

--- a/checks/53D035.yaml
+++ b/checks/53D035.yaml
@@ -37,7 +37,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   AWS:
 

--- a/checks/553B84.yaml
+++ b/checks/553B84.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/553B85.yaml
+++ b/checks/553B85.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/553B86.yaml
+++ b/checks/553B86.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/553B87.yaml
+++ b/checks/553B87.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/553B88.yaml
+++ b/checks/553B88.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/553B89.yaml
+++ b/checks/553B89.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/553B8A.yaml
+++ b/checks/553B8A.yaml
@@ -21,7 +21,7 @@ remediation: |
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphanatopology.html
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphanatopology

--- a/checks/62A0E0.yaml
+++ b/checks/62A0E0.yaml
@@ -32,7 +32,7 @@ remediation: |
 
   GCP:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ascs-instance
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ascs-instance

--- a/checks/6E9B82.yaml
+++ b/checks/6E9B82.yaml
@@ -35,7 +35,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   AWS:
 

--- a/checks/790926.yaml
+++ b/checks/790926.yaml
@@ -24,7 +24,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles
 
   Nutanix:
 

--- a/checks/7E0221.yaml
+++ b/checks/7E0221.yaml
@@ -53,7 +53,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   SUSE / KVM:
 

--- a/checks/7E7F18.yaml
+++ b/checks/7E7F18.yaml
@@ -50,7 +50,7 @@ remediation: |
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-configuring-the-resources-for-the-ers-instance
     - https://documentation.suse.com/en-us/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ers-instance
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-configuring-the-resources-for-the-ascs-instance
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#create_the_vip_resources
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#create_the_vip_resources
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-configuring-the-resources-for-the-ascs-instance

--- a/checks/802D5D.yaml
+++ b/checks/802D5D.yaml
@@ -53,7 +53,7 @@ remediation: |
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-configuring-the-resources-for-the-ers-instance
     - https://documentation.suse.com/en-us/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ers-instance
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-configuring-the-resources-for-the-ascs-instance
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#create_the_file_system_resources
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#create_the_file_system_resources
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-configuring-the-resources-for-the-ascs-instance

--- a/checks/822E47.yaml
+++ b/checks/822E47.yaml
@@ -35,7 +35,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   SUSE / KVM:
 

--- a/checks/83952D.yaml
+++ b/checks/83952D.yaml
@@ -24,7 +24,7 @@ remediation: |
 
   GCP:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ers-instance
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ers-instance

--- a/checks/845CC9.yaml
+++ b/checks/845CC9.yaml
@@ -36,7 +36,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   AWS:
 

--- a/checks/8D5080.yaml
+++ b/checks/8D5080.yaml
@@ -24,7 +24,7 @@ remediation: |
 
   GCP:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-1.8.8.8.5
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#configure_the_resource_groups_and_location_constraints
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#configure_the_resource_groups_and_location_constraints
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-1.8.8.8.5

--- a/checks/9CFD28.yaml
+++ b/checks/9CFD28.yaml
@@ -22,7 +22,7 @@ remediation: |
       ## AWS has a different resource agent for virtual IP and different values for interval and timeout for monitor operation for virtual IP resource configured
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
       ## GCP has the same resource agent IPaddr2 but different values for interval and timeout for monitor operations.
 
   SUSE / KVM:

--- a/checks/9CFD29.yaml
+++ b/checks/9CFD29.yaml
@@ -22,7 +22,7 @@ remediation: |
       ## AWS has a different resource agent for virtual IP and different values for interval and timeout for monitor operation for virtual IP resource configured
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
       ## GCP has the same resource agent IPaddr2 but different values for interval and timeout for monitor operations.
 
   SUSE / KVM:

--- a/checks/9CFD2A.yaml
+++ b/checks/9CFD2A.yaml
@@ -22,7 +22,7 @@ remediation: |
       ## AWS has a different resource agent for virtual IP and different values for interval and timeout for the monitor operation for the virtual IP resource configured
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
       ## GCP has the same resource agent IPaddr2 but different values for interval and timeout for monitor operations.
 
   SUSE / KVM:

--- a/checks/A1244C.yaml
+++ b/checks/A1244C.yaml
@@ -35,7 +35,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   AWS:
 

--- a/checks/ABA3CA.yaml
+++ b/checks/ABA3CA.yaml
@@ -26,6 +26,8 @@ remediation: |
 
   GCP:
 
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#verify_that_sap_host_agent_is_receiving_metrics
+
   SUSE / KVM:
 
     - https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#cha.s4s.hana-install

--- a/checks/AE0C5F.yaml
+++ b/checks/AE0C5F.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C60.yaml
+++ b/checks/AE0C60.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C61.yaml
+++ b/checks/AE0C61.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C62.yaml
+++ b/checks/AE0C62.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C63.yaml
+++ b/checks/AE0C63.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C64.yaml
+++ b/checks/AE0C64.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C65.yaml
+++ b/checks/AE0C65.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C67.yaml
+++ b/checks/AE0C67.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C68.yaml
+++ b/checks/AE0C68.yaml
@@ -24,7 +24,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles
 
   SUSE / KVM:
 

--- a/checks/AE0C69.yaml
+++ b/checks/AE0C69.yaml
@@ -24,7 +24,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles
 
   SUSE / KVM:
 

--- a/checks/AE0C6A.yaml
+++ b/checks/AE0C6A.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C6B.yaml
+++ b/checks/AE0C6B.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
 

--- a/checks/AE0C6C.yaml
+++ b/checks/AE0C6C.yaml
@@ -21,7 +21,7 @@ remediation: |
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-saphana.html
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp5-or-earlier
 
   SUSE / KVM:
     - https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-saphana

--- a/checks/B3DA7E.yaml
+++ b/checks/B3DA7E.yaml
@@ -32,8 +32,8 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#set_the_additional_cluster_properties
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#set_the_additional_cluster_properties
 
   Nutanix:
 

--- a/checks/BA215C.yaml
+++ b/checks/BA215C.yaml
@@ -20,7 +20,7 @@ remediation: |
     - https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration.html
 
   GCP:
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   Nutanix:
 

--- a/checks/C15B2C.yaml
+++ b/checks/C15B2C.yaml
@@ -42,7 +42,7 @@ remediation: |
   GCP:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-resources-for-the-ascs
     - https://documentation.suse.com/sle-ha/15-SP5/single-html/SLE-HA-administration/#pro-ha-storage-protect-fencing
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-resources-for-the-ascs

--- a/checks/C620DC.yaml
+++ b/checks/C620DC.yaml
@@ -34,7 +34,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   AWS:
 

--- a/checks/CAEFF1.yaml
+++ b/checks/CAEFF1.yaml
@@ -25,7 +25,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-os-support#quick_reference_table
+    - https://docs.cloud.google.com/sap/docs/sap-hana-os-support#quick_reference_table
 
   Nutanix:
 

--- a/checks/CCEF3B.yaml
+++ b/checks/CCEF3B.yaml
@@ -24,7 +24,7 @@ remediation: |
 
   GCP:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-1.8.8.7.4
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#configure_the_resource_groups_and_location_constraints
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#configure_the_resource_groups_and_location_constraints
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-sle15/index.html#id-1.8.8.7.4

--- a/checks/D78671.yaml
+++ b/checks/D78671.yaml
@@ -36,7 +36,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   SUSE / KVM:
 

--- a/checks/DA114A.yaml
+++ b/checks/DA114A.yaml
@@ -21,7 +21,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_corosync_configuration_files
 
   SUSE / KVM:
 

--- a/checks/DAD58C.yaml
+++ b/checks/DAD58C.yaml
@@ -24,7 +24,7 @@ remediation: |
 
   GCP:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ascs-instance
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html#id-configuring-resources-for-the-ascs-instance

--- a/checks/E1F2C3.yaml
+++ b/checks/E1F2C3.yaml
@@ -27,8 +27,8 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-scaleout-config-sles#sles-for-sap-15-sp6-or-later
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_saphana_or_saphanacontroller_primitive_resource
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-scaleout-config-sles#sles-for-sap-15-sp6-or-later
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_saphana_or_saphanacontroller_primitive_resource
 
   SUSE / KVM:
 

--- a/checks/E215A6.yaml
+++ b/checks/E215A6.yaml
@@ -24,7 +24,7 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-scaleout-config-sles#create_the_saphanafilesystem_primitive_resource
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-scaleout-config-sles#create_the_saphanafilesystem_primitive_resource
 
   SUSE / KVM:
 

--- a/checks/E4D1B4.yaml
+++ b/checks/E4D1B4.yaml
@@ -27,8 +27,8 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-scaleout-config-sles#create_the_saphanatopology_primitive_resource
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_saphanatopology_primitive_resource
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-scaleout-config-sles#create_the_saphanatopology_primitive_resource
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#create_the_saphanatopology_primitive_resource
 
   SUSE / KVM:
 

--- a/checks/EA12BC.yaml
+++ b/checks/EA12BC.yaml
@@ -27,8 +27,8 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-scaleout-config-sles#sles-for-sap-15-sp6-or-later_5
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp6-or-later_3
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-scaleout-config-sles#sles-for-sap-15-sp6-or-later_5
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp6-or-later_3
 
   SUSE / KVM:
 

--- a/checks/EB24D1.yaml
+++ b/checks/EB24D1.yaml
@@ -27,8 +27,8 @@ remediation: |
 
   GCP:
 
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-scaleout-config-sles#sles-for-sap-15-sp6-or-later_5
-    - https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp6-or-later_3
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-scaleout-config-sles#sles-for-sap-15-sp6-or-later_5
+    - https://docs.cloud.google.com/sap/docs/sap-hana-ha-config-sles#sles-for-sap-15-sp6-or-later_3
 
   SUSE / KVM:
 

--- a/checks/F306C2.yaml
+++ b/checks/F306C2.yaml
@@ -42,7 +42,7 @@ remediation: |
   GCP:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-resources-for-the-ascs
     - https://documentation.suse.com/sle-ha/15-SP5/single-html/SLE-HA-administration/#pro-ha-storage-protect-fencing
-    - https://cloud.google.com/solutions/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
+    - https://docs.cloud.google.com/sap/docs/netweaver-ha-config-sles#configure_the_cluster_resources_for_ascs_and_ers
 
   Nutanix:
     - https://documentation.suse.com/sbp/sap-15/html/SAP-nw740-sle15-setupguide/index.html#id-configuring-the-resources-for-the-ascs


### PR DESCRIPTION
### Description

This PR updates the documentation links in some checks; particularly, here we are updating those related to GCP.

Fixes #[TRNT-4600](https://jira.suse.com/browse/TRNT-4600)

### How was this tested?

N/A

### Documentation changes

N/A

### Additional information

Part of the PR saga:

- [ ] https://github.com/trento-project/checks/pull/84
- [ ] https://github.com/trento-project/checks/pull/85
- [ ] https://github.com/trento-project/checks/pull/86
- [ ] https://github.com/trento-project/checks/pull/87
- [ ] https://github.com/trento-project/checks/pull/88