### PR TITLE
Use package_version gatherer for stonith/fencing names

### DIFF
--- a/checks/205AF7.yaml
+++ b/checks/205AF7.yaml
@@ -61,52 +61,44 @@ facts:
   - name: crm_config_properties
     gatherer: cibadmin@v1
     argument: cib.configuration.crm_config.cluster_property_set
-  - name: crm_feature_set
-    gatherer: cibadmin@v1
-    argument: cib.crm_feature_set
+  # package_version@v1 runs `zypper versioncmp <argument> <installed>`, so the result compares the
+  # *requested* version to the installed one: -1 installed newer, 0 equal, 1 installed older.
+  - name: pacemaker_version_cmp
+    gatherer: package_version@v1
+    argument: pacemaker,3.0.2
 
+# The two spellings of the same cluster property. Which one is authoritative depends on the running Pacemaker version
 values:
-  - name: expected_crm_feature_set_pacemaker_302
-    default: "3.20.0"
+  - name: modern_property
+    customization_disabled: true
+    default: "fencing-enabled"
+  - name: legacy_property
+    customization_disabled: true
+    default: "stonith-enabled"
 
 expectations:
   - name: expectations_fencing_enabled
     expect_enum: |
+      // Pacemaker 3.0.2 renamed "stonith-enabled" to "fencing-enabled".
+      let convention = switch facts.pacemaker_version_cmp {
+        1 => #{ authoritative: values.legacy_property, deprecated: values.modern_property }, // installed Pacemaker is older than 3.0.2
+        _ => #{ authoritative: values.modern_property, deprecated: values.legacy_property }, // installed Pacemaker is 3.0.2 or newer
+      };
+
       let bootstrap = facts.crm_config_properties.find(|item| item.id == "cib-bootstrap-options").nvpair;
-      let fencing_enabled = bootstrap.find(|prop| prop.name == "fencing-enabled");
-      let stonith_enabled = bootstrap.find(|prop| prop.name == "stonith-enabled");
 
-      let fencing_enabled_ok = fencing_enabled != () && fencing_enabled.value == true;
-      let stonith_enabled_ok = stonith_enabled != () && stonith_enabled.value == true;
+      let authoritative = bootstrap.find(|prop| prop.name == convention.authoritative);
+      let deprecated = bootstrap.find(|prop| prop.name == convention.deprecated);
 
-      let feature_set = facts.crm_feature_set.split(".").map(|part| parse_int(part));
-      let threshold = values.expected_crm_feature_set_pacemaker_302.split(".").map(|part| parse_int(part));
-      let is_pacemaker_302_or_newer = feature_set[0] > threshold[0] || (feature_set[0] == threshold[0] && feature_set[1] >= threshold[1]);
+      // The property Pacemaker acts on: the authoritative one when set, the other one otherwise.
+      let fencing_enabled = (authoritative ?? deprecated)?.value == true;
+      let follows_convention = authoritative != () && deprecated == ();
 
-      // On Pacemaker 3.0.2+, "fencing-enabled" is the authoritative property and "stonith-enabled" is deprecated.
-      // Before Pacemaker 3.0.2 it is the other way round: "stonith-enabled" is authoritative and "fencing-enabled" is not even recognized by Pacemaker.
-
-      let authoritative_property = if is_pacemaker_302_or_newer { fencing_enabled } else { stonith_enabled };
-      let authoritative_property_enabled = if is_pacemaker_302_or_newer { fencing_enabled_ok } else { stonith_enabled_ok };
-      let deprecated_property = if is_pacemaker_302_or_newer { stonith_enabled } else { fencing_enabled };
-      let deprecated_property_enabled = if is_pacemaker_302_or_newer { stonith_enabled_ok } else { fencing_enabled_ok };
-
-      // - passing:  the authoritative property is correctly set to true, and the deprecated property is not present.
-      // - warning:  the authoritative property is correctly set to true, but the deprecated property is also present and should be cleaned up;
-      //             or the authoritative property is absent, but fencing still works because the deprecated property is correctly set to true.
-      // - critical: the authoritative property is present but not set to true; or the authoritative property is absent and the deprecated property isn't correctly set to true either.
-
-      if authoritative_property != () {
-        if authoritative_property_enabled {
-          if deprecated_property != () { "warning" } else { "passing" }
-        } else {
-          "critical"
-        }
-      } else if deprecated_property_enabled {
-        "warning"
-      } else {
-        "critical"
+      switch [fencing_enabled, follows_convention] {
+        [true, true] => "passing", // fencing is enabled, and only the property matching the running Pacemaker version is set.
+        [true, false] => "warning", // fencing is enabled, but the property from the other convention is set as well, or is the only one set.
+        _ => "critical", // fencing is not enabled.
       }
 
-    warning_message: Fencing is enabled, but the cluster properties do not fully match the convention for the detected Pacemaker version. Either fencing relies on the deprecated/unrecognized property, or a leftover property from the other convention is still present alongside the correct one. The cluster is functional but the configuration should be migrated to only use the property matching the running Pacemaker version.
-    failure_message: Fencing was expected to be enabled in the cluster configuration, but neither 'fencing-enabled' nor 'stonith-enabled' is correctly set to true for the detected Pacemaker version.
+    warning_message: Fencing is enabled, but the cluster properties do not fully match the convention for the running Pacemaker version. Only '${switch facts.pacemaker_version_cmp { 1 => values.legacy_property, _ => values.modern_property }}' should be set to true; '${switch facts.pacemaker_version_cmp { 1 => values.modern_property, _ => values.legacy_property }}' should not be set. The cluster is functional but the configuration should be migrated.
+    failure_message: Fencing was expected to be enabled in the cluster configuration, but '${switch facts.pacemaker_version_cmp { 1 => values.legacy_property, _ => values.modern_property }}' is not correctly set to true for the running Pacemaker version.

--- a/checks/373DB8.yaml
+++ b/checks/373DB8.yaml
@@ -65,10 +65,13 @@ facts:
   - name: resources_primitives
     gatherer: cibadmin@v1
     argument: cib.configuration.resources.primitive
-  - name: crm_feature_set
-    gatherer: cibadmin@v1
-    argument: cib.crm_feature_set
+  # package_version@v1 runs `zypper versioncmp <argument> <installed>`, so the result compares the
+  # *requested* version to the installed one: -1 installed newer, 0 equal, 1 installed older.
+  - name: pacemaker_version_cmp
+    gatherer: package_version@v1
+    argument: pacemaker,3.0.2
 
+# The two spellings of the same cluster property. Which one is authoritative depends on the running Pacemaker version
 values:
   - name: expected_fencing_timeout
     default: 150
@@ -83,15 +86,26 @@ values:
   - name: expected_azure_arm_fencing_timeout
     default: 900
 
-  - name: expected_crm_feature_set_pacemaker_302
-    default: "3.20.0"
+  - name: modern_property
+    customization_disabled: true
+    default: "fencing-timeout"
+  - name: legacy_property
+    customization_disabled: true
+    default: "stonith-timeout"
 
 expectations:
   - name: expectations_fencing_timeout
     expect_enum: |
-      let bootstrap_nvpairs = facts.crm_config_properties.find(|item| item.id == "cib-bootstrap-options").nvpair;
-      let fencing_timeout = bootstrap_nvpairs.find(|prop| prop.name == "fencing-timeout");
-      let stonith_timeout = bootstrap_nvpairs.find(|prop| prop.name == "stonith-timeout");
+      // Pacemaker 3.0.2 renamed "stonith-timeout" to "fencing-timeout".
+      let convention = switch facts.pacemaker_version_cmp {
+        1 => #{ authoritative: values.legacy_property, deprecated: values.modern_property }, // installed Pacemaker is older than 3.0.2
+        _ => #{ authoritative: values.modern_property, deprecated: values.legacy_property }, // installed Pacemaker is 3.0.2 or newer
+      };
+
+      let bootstrap = facts.crm_config_properties.find(|item| item.id == "cib-bootstrap-options").nvpair;
+
+      let authoritative = bootstrap.find(|prop| prop.name == convention.authoritative);
+      let deprecated = bootstrap.find(|prop| prop.name == convention.deprecated);
 
       let fence_azure_arm_detected = facts.resources_primitives.filter(|item| item.type == "fence_azure_arm").len() != 0;
 
@@ -101,38 +115,16 @@ expectations:
         values.expected_fencing_timeout
       };
 
-      let fencing_timeout_ok = fencing_timeout != () && fencing_timeout.value >= expected_timeout;
-      let stonith_timeout_ok = stonith_timeout != () && stonith_timeout.value >= expected_timeout;
+      // The timeout Pacemaker acts on: from the authoritative property when set, the deprecated one otherwise.
+      let effective_timeout = (authoritative ?? deprecated)?.value;
+      let timeout_ok = effective_timeout != () && effective_timeout >= expected_timeout;
+      let follows_convention = authoritative != () && deprecated == ();
 
-      let feature_set = facts.crm_feature_set.split(".").map(|part| parse_int(part));
-      let threshold = values.expected_crm_feature_set_pacemaker_302.split(".").map(|part| parse_int(part));
-      let is_pacemaker_302_or_newer = feature_set[0] > threshold[0] || (feature_set[0] == threshold[0] && feature_set[1] >= threshold[1]);
-
-      // On Pacemaker 3.0.2+, "fencing-timeout" is the authoritative property and "stonith-timeout" is deprecated.
-      // Before Pacemaker 3.0.2 it is the other way round: "stonith-timeout" is authoritative and "fencing-timeout" is not even recognized by Pacemaker.
-
-      let authoritative_property = if is_pacemaker_302_or_newer { fencing_timeout } else { stonith_timeout };
-      let authoritative_property_ok = if is_pacemaker_302_or_newer { fencing_timeout_ok } else { stonith_timeout_ok };
-      let deprecated_property = if is_pacemaker_302_or_newer { stonith_timeout } else { fencing_timeout };
-      let deprecated_property_ok = if is_pacemaker_302_or_newer { stonith_timeout_ok } else { fencing_timeout_ok };
-
-      // - passing:  the authoritative property meets the expected timeout, and the deprecated property is not present.
-      // - warning:  the authoritative property meets the expected timeout, but the deprecated property is also present and should be cleaned up;
-      //             or the authoritative property is absent, but the expected timeout is still met by the deprecated property.
-      // - critical: the authoritative property is present but does not meet the expected timeout;
-      //             or the authoritative property is absent and the deprecated property doesn't meet it either.
-
-      if authoritative_property != () {
-        if authoritative_property_ok {
-          if deprecated_property != () { "warning" } else { "passing" }
-        } else {
-          "critical"
-        }
-      } else if deprecated_property_ok {
-        "warning"
-      } else {
-        "critical"
+      switch [timeout_ok, follows_convention] {
+        [true, true] => "passing", // timeout meets the expectation, and only the property matching the running Pacemaker version is set.
+        [true, false] => "warning", // timeout meets the expectation, but the property from the other convention is set as well, or is the only one set.
+        _ => "critical", // timeout does not meet the expectation.
       }
 
-    warning_message: Cluster fencing timeout is configured, but the cluster properties do not fully match the convention for the detected Pacemaker version. Either the timeout relies on the deprecated/unrecognized property, or a leftover property from the other convention is still present alongside the correct one. The cluster is functional but the configuration should be migrated to only use the property matching the running Pacemaker version.
-    failure_message: Cluster fencing timeout ('fencing-timeout' in Pacemaker 3.0.2+, 'stonith-timeout' in older versions) is not configured correctly for the detected Pacemaker version
+    warning_message: Cluster fencing timeout is configured, but the cluster properties do not fully match the convention for the running Pacemaker version. Only '${switch facts.pacemaker_version_cmp { 1 => values.legacy_property, _ => values.modern_property }}' should be set; '${switch facts.pacemaker_version_cmp { 1 => values.modern_property, _ => values.legacy_property }}' should not be set. The cluster is functional but the configuration should be migrated.
+    failure_message: Cluster fencing timeout was expected to be configured correctly, but '${switch facts.pacemaker_version_cmp { 1 => values.legacy_property, _ => values.modern_property }}' is not correctly set for the running Pacemaker version.


### PR DESCRIPTION
### Description

This is an alternative version based upon https://github.com/trento-project/checks/pull/77#discussion_r3681469558:

--- 
This pull request updates the fencing checks for Pacemaker clusters to support both legacy (`stonith-*`) and new (`fencing-*`) property names, reflecting changes introduced in Pacemaker 3.0.2. The checks and documentation now detect and remediate both property names for better compatibility across Pacemaker versions.

**Fencing property compatibility updates:**

* Updated the `205AF7` fencing enabled check to recognize both `fencing-enabled` (Pacemaker 3.0.2+) and `stonith-enabled` (older versions), including logic in the expectation and updated remediation instructions.
* Updated the `373DB8` fencing timeout check to recognize both `fencing-timeout` (Pacemaker 3.0.2+) and `stonith-timeout` (older versions), including expectation logic, descriptions, and remediation instructions.

Fixes #[TRNT-4562](https://jira.suse.com/browse/TRNT-4562)

### How was this tested?

N/A

### Documentation changes

No

### Additional information

Part of the PR saga:

- [ ] https://github.com/trento-project/checks/pull/77
- [ ] https://github.com/trento-project/agent/pull/610 
- [ ] https://github.com/trento-project/web/pull/4474
- [ ] https://github.com/trento-project/barbecue/pull/12